### PR TITLE
fix: only consider matching ingress class

### DIFF
--- a/pkg/controller/ingress-controller.go
+++ b/pkg/controller/ingress-controller.go
@@ -135,7 +135,16 @@ func (i *IngressController) listControlledIngressClasses(ctx context.Context) ([
 	if err != nil {
 		return nil, errors.Wrap(err, "list ingress classes")
 	}
-	return list.Items, nil
+	
+	filteredList := make([]networkingv1.IngressClass, 0, len(list.Items))
+	for _, ingress := range list.Items {
+		if ingress.Spec.Controller != i.controllerClassName {
+			continue
+		}
+		filteredList = append(filteredList, ingress)
+	}
+
+	return filteredList, nil
 }
 
 func (i *IngressController) listControlledIngresses(ctx context.Context) ([]networkingv1.Ingress, error) {


### PR DESCRIPTION
Thank you for writing this project. I ran into an issue when running this project in my cluster with 2 ingresses (an existing ingress class for nginx, and this one):
```
❯ kubectl get ingressclass
NAME                CONTROLLER                                       PARAMETERS
nginx               k8s.io/ingress-nginx                             <none>       
cloudflare-tunnel   strrl.dev/cloudflare-tunnel-ingress-controller   <none> 
```

It seemed to consider the ingress configuration no matter which ingress class I had set on the ingress object, which meant it tried to configure all the ingresses including the ones nginx was managing. This PR prevents that by filtering the controlled ingress classes to the ones that match the set controller class name. 