### PR TITLE
Add support for more origin service configuration

### DIFF
--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: CLOUDFLARED_IMAGE
               value: "{{ .Values.cloudflared.image.repository }}:{{ .Values.cloudflared.image.tag }}"
             - name: CLOUDFLARED_IMAGE_PULL_POLICY
@@ -82,6 +86,10 @@ spec:
               value: {{ .Values.cloudflared.replicaCount | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if gt (len .Values.extraVolumeMounts) 0 }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -93,4 +101,8 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.extraVolumes) 0 }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -71,6 +71,14 @@ tolerations: []
 
 affinity: {}
 
+# Any additional volumes to include in the controller deployment.
+# Note: These will be forwarded to the cloudflared deployment as well.
+extraVolumes: []
+
+# Any additional volumes to mount in the controller pod.
+# Note: These will be forwarded to the cloudflared pod as well.
+extraVolumeMounts: []
+
 cloudflared:
   image:
     repository: cloudflare/cloudflared

--- a/pkg/controller/weel_known_annotations.go
+++ b/pkg/controller/weel_known_annotations.go
@@ -1,9 +1,0 @@
-package controller
-
-// AnnotationProxySSLVerify is the annotation key for proxy-ssl-verify, available values: "on" or "off", default "off".
-const AnnotationProxySSLVerify = "cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify"
-const AnnotationProxySSLVerifyOn = "on"
-const AnnotationProxySSLVerifyOff = "off"
-
-// AnnotationBackendProtocol is the annotation key for proxy-backend-protocol, default "http".
-const AnnotationBackendProtocol = "cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol"

--- a/pkg/controller/well_known_annotations.go
+++ b/pkg/controller/well_known_annotations.go
@@ -1,0 +1,18 @@
+package controller
+
+// AnnotationProxySSLVerify is the annotation key for proxy-ssl-verify, available values: "on" or "off", default "off".
+const AnnotationProxySSLVerify = "cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify"
+const AnnotationProxySSLVerifyOn = "on"
+const AnnotationProxySSLVerifyOff = "off"
+
+// AnnotationBackendProtocol is the annotation key for proxy-backend-protocol, default "http".
+const AnnotationBackendProtocol = "cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol"
+
+// AnnotationOriginServerName is the annotation for the hostname that cloudflared should expect from your origin server certificate. If null, the expected hostname is the service URL, for example localhost if the service is https://localhost:443.
+const AnnotationOriginServerName = "cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name"
+
+// AnnotationCAPool is the annotation for the path to the certificate authority (CA) for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
+const AnnotationCAPool = "cloudflare-tunnel-ingress-controller.strrl.dev/origin-capool"
+
+// AnnotationTLSTimeout is the timeout for completing a TLS handshake to your origin server, if you have chosen to connect Tunnel to an HTTPS server.
+const AnnotationTLSTimeout = "cloudflare-tunnel-ingress-controller.strrl.dev/origin-tls-timeout"

--- a/pkg/exposure/exposure.go
+++ b/pkg/exposure/exposure.go
@@ -1,5 +1,7 @@
 package exposure
 
+import "time"
+
 // Exposure is the minimal information for exposing a service.
 type Exposure struct {
 	// Hostname is the domain name to expose the service, eg. hello.strrl.dev
@@ -10,6 +12,13 @@ type Exposure struct {
 	PathPrefix string
 	// IsDeleted is the flag to indicate if the exposure is deleted.
 	IsDeleted bool
-	// ProxySSLVerifyEnabled is the flag to indicate if the exposure should skip TLS verification.
-	ProxySSLVerifyEnabled *bool
+	// OriginServerName is the hostname that cloudflared should expect from your origin server certificate. If null, the expected hostname is the service URL, for example localhost if the service is https://localhost:443.
+	OriginServerName *string
+	// CAPool is the path to the certificate authority (CA) for the certificate of your origin. This option should be used only if your certificate is not signed by Cloudflare.
+	CAPool *string
+	// When false, TLS verification is performed on the certificate presented by your origin.
+	// When true, TLS verification is disabled. This will allow any certificate from the origin to be accepted.
+	NoTLSVerify *bool
+	// TLSTimeout is the timeout for completing a TLS handshake to your origin server, if you have chosen to connect Tunnel to an HTTPS server.
+	TLSTimeout *time.Duration
 }


### PR DESCRIPTION
Adds support for a few more origin service settings via annotations similar to proxy ssl verify.

https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/origin-configuration/

I tried to follow the existing conventions, but I did make a minor refactor around ProxySSLVerify/NoTLSVerify. Let me know if there's anything you want changed!

I believe this should resolve #11 and #16