### PR TITLE
Support specifying an alternate number of replicas for cloudflared

### DIFF
--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -21,12 +21,13 @@ type rootCmdFlags struct {
 	// for annotation on Ingress
 	ingressClass string
 	// for IngressClass.spec.controller
-	controllerClass      string
-	logLevel             int
-	cloudflareAPIToken   string
-	cloudflareAccountId  string
-	cloudflareTunnelName string
-	namespace            string
+	controllerClass         string
+	logLevel                int
+	cloudflareAPIToken      string
+	cloudflareAccountId     string
+	cloudflareTunnelName    string
+	namespace               string
+	cloudflaredReplicaCount int32
 }
 
 func main() {
@@ -99,7 +100,13 @@ func main() {
 					case <-done:
 						return
 					case _ = <-ticker.C:
-						err := controller.CreateControlledCloudflaredIfNotExist(ctx, mgr.GetClient(), tunnelClient, options.namespace)
+						err := controller.CreateControlledCloudflaredIfNotExist(
+							ctx,
+							mgr.GetClient(),
+							tunnelClient,
+							options.namespace,
+							options.cloudflaredReplicaCount,
+						)
 						if err != nil {
 							logger.WithName("controlled-cloudflared").Error(err, "create controlled cloudflared")
 						}
@@ -119,6 +126,7 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.cloudflareAccountId, "cloudflare-account-id", options.cloudflareAccountId, "cloudflare account id")
 	rootCommand.PersistentFlags().StringVar(&options.cloudflareTunnelName, "cloudflare-tunnel-name", options.cloudflareTunnelName, "cloudflare tunnel name")
 	rootCommand.PersistentFlags().StringVar(&options.namespace, "namespace", options.namespace, "namespace to execute cloudflared connector")
+	rootCommand.PersistentFlags().Int32Var(&options.cloudflaredReplicaCount, "cloudflared-replica-count", options.cloudflaredReplicaCount, "namespace to execute cloudflared connector")
 
 	err := rootCommand.Execute()
 	if err != nil {

--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -21,13 +21,12 @@ type rootCmdFlags struct {
 	// for annotation on Ingress
 	ingressClass string
 	// for IngressClass.spec.controller
-	controllerClass         string
-	logLevel                int
-	cloudflareAPIToken      string
-	cloudflareAccountId     string
-	cloudflareTunnelName    string
-	namespace               string
-	cloudflaredReplicaCount int32
+	controllerClass      string
+	logLevel             int
+	cloudflareAPIToken   string
+	cloudflareAccountId  string
+	cloudflareTunnelName string
+	namespace            string
 }
 
 func main() {
@@ -100,13 +99,7 @@ func main() {
 					case <-done:
 						return
 					case _ = <-ticker.C:
-						err := controller.CreateControlledCloudflaredIfNotExist(
-							ctx,
-							mgr.GetClient(),
-							tunnelClient,
-							options.namespace,
-							options.cloudflaredReplicaCount,
-						)
+						err := controller.CreateControlledCloudflaredIfNotExist(ctx, mgr.GetClient(), tunnelClient, options.namespace)
 						if err != nil {
 							logger.WithName("controlled-cloudflared").Error(err, "create controlled cloudflared")
 						}
@@ -126,7 +119,6 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.cloudflareAccountId, "cloudflare-account-id", options.cloudflareAccountId, "cloudflare account id")
 	rootCommand.PersistentFlags().StringVar(&options.cloudflareTunnelName, "cloudflare-tunnel-name", options.cloudflareTunnelName, "cloudflare tunnel name")
 	rootCommand.PersistentFlags().StringVar(&options.namespace, "namespace", options.namespace, "namespace to execute cloudflared connector")
-	rootCommand.PersistentFlags().Int32Var(&options.cloudflaredReplicaCount, "cloudflared-replica-count", options.cloudflaredReplicaCount, "namespace to execute cloudflared connector")
 
 	err := rootCommand.Execute()
 	if err != nil {

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - --cloudflare-account-id=$(CLOUDFLARE_ACCOUNT_ID)
             - --cloudflare-tunnel-name=$(CLOUDFLARE_TUNNEL_NAME)
             - --namespace=$(NAMESPACE)
+            - --cloudflared-replica-count={{ .Values.cloudflared.replicaCount }}
           env:
             - name: CLOUDFLARE_API_TOKEN
               valueFrom:

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
             - --cloudflare-account-id=$(CLOUDFLARE_ACCOUNT_ID)
             - --cloudflare-tunnel-name=$(CLOUDFLARE_TUNNEL_NAME)
             - --namespace=$(NAMESPACE)
-            - --cloudflared-replica-count={{ .Values.cloudflared.replicaCount }}
           env:
             - name: CLOUDFLARE_API_TOKEN
               valueFrom:
@@ -79,6 +78,8 @@ spec:
               value: "{{ .Values.cloudflared.image.repository }}:{{ .Values.cloudflared.image.tag }}"
             - name: CLOUDFLARED_IMAGE_PULL_POLICY
               value: {{ .Values.cloudflared.image.pullPolicy | quote }}
+            - name: CLOUDFLARED_REPLICA_COUNT
+              value: {{ .Values.cloudflared.replicaCount | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -21,6 +21,9 @@ ingressClass:
 
 replicaCount: 1
 
+cloudflared:
+  replicaCount: 1
+
 image:
   repository: ghcr.io/strrl/cloudflare-tunnel-ingress-controller
   pullPolicy: IfNotPresent

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -21,9 +21,6 @@ ingressClass:
 
 replicaCount: 1
 
-cloudflared:
-  replicaCount: 1
-
 image:
   repository: ghcr.io/strrl/cloudflare-tunnel-ingress-controller
   pullPolicy: IfNotPresent
@@ -79,3 +76,4 @@ cloudflared:
     repository: cloudflare/cloudflared
     pullPolicy: IfNotPresent
     tag: latest
+  replicaCount: 1


### PR DESCRIPTION
Cloudflared should [support HA configurations out of the box](https://blog.cloudflare.com/highly-available-and-highly-scalable-cloudflare-tunnels/) with no extra work from the controller.

This also means it should be possible to support a DaemonSet option for cloudflared.