### PR TITLE
fix(helm): existing secret was not read properly

### DIFF
--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                 secretKeyRef:
                   {{- if hasKey .Values.cloudflare "secretRef" }}
                   name: {{ .Values.cloudflare.secretRef.name }}
-                  key: {{ .Values.cloudflare.secretRef.apiTokenKey }}
+                  key: apiTokenKey
                   {{- else }}
                   name: cloudflare-api
                   key: api-token
@@ -55,7 +55,7 @@ spec:
                 secretKeyRef:
                   {{- if hasKey .Values.cloudflare "secretRef" }}
                   name: {{ .Values.cloudflare.secretRef.name }}
-                  key: {{ .Values.cloudflare.secretRef.accountIDKey }}
+                  key: accountIDKey 
                   {{- else }}
                   name: cloudflare-api
                   key: cloudflare-account-id
@@ -65,7 +65,7 @@ spec:
                 secretKeyRef:
                   {{- if hasKey .Values.cloudflare "secretRef" }}
                   name: {{ .Values.cloudflare.secretRef.name }}
-                  key: {{ .Values.cloudflare.secretRef.tunnelNameKey }}
+                  key: tunnelNameKey
                   {{- else }}
                   name: cloudflare-api
                   key: cloudflare-tunnel-name


### PR DESCRIPTION
Hello,

I wanted to use an existing secret to log to Cloudflare API, but I had following errors:
```
The Deployment "cloudflare-tunnel-ingress-controller" is invalid: 
* spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key: Required value
* spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key: Required value
* spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.key: Required value
```

I use Kustomize, and seen in your chart that you allow "secretRef" for existing secret:
```
helmCharts:
- name: cloudflare-tunnel-ingress-controller
  repo: https://helm.strrl.dev
  releaseName: cloudflare-tunnel-ingress-controller
  namespace: cloudflared-ingress-controller
  version: 0.0.13
  valuesInline:
    cloudflare:
      secretRef:
        name: cloudflared-api
```

Here a small PR I hope you will appreciate this proposal to fix deployment chart by properly loading keys inside the secret instead of trying to load non existant values.

I would suggest you also to talk about using existing secret, as it's in your chart but haven't seen it mentionned anywhere ˆˆ.

Thank you!

-- o_be_one