### PR TITLE
Allow tunnel to ssh ports

### DIFF
--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -100,6 +100,11 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				return nil, errors.Errorf("path type in ingress %s/%s is %s, which is not supported", ingress.GetNamespace(), ingress.GetName(), *path.PathType)
 			}
 
+			if scheme == "ssh" {
+				path = networkingv1.HTTPIngressPath{}
+				logger.Info("ssh scheme detected, ignoring path")
+			}
+
 			result = append(result, exposure.Exposure{
 				Hostname:              hostname,
 				ServiceTarget:         fmt.Sprintf("%s://%s:%d", scheme, host, port),


### PR DESCRIPTION
I wondered if its possible to expose both http and ssh ports of a pod.
In my case I deployed gitea which has both.

After making the tunnel work by manually changing the tunnel configuration, I figgured what was missing:
- in case of http(s) protocol the `path` make sense
- for ssh (and probably for `tcp`) type it shouldn't be set

With a simple check I made the controller successfully expose my gitea ssh service via a cloudflare tunnel.

## Example

Here is an ingress with all details:
```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: "ssh"
  name: gitea-ssh
  namespace: gitea
spec:
  ingressClassName: cloudflare-tunnel
  rules:
  - host: ssh.mydomain.com
    http:
      paths:
        - path: '/*'
          pathType: ImplementationSpecific
          backend:
            service:
              name: gitea-ssh
              port:
                number: 2222
```

I was using the official helm chart to deploy gitea, and first the svc had a couple of issue:
- it was headless (ClusteIp: None) which is not supported
- there was a port mapping 22->2222 (port:22, targetPort:2222) which is convenient inside the cluster, so one can ssh with a servicename, skipping the port spec, but it did not work

The final relevant chart values to fix the service:

```
helm upgrade -i  \
  gitea \
  --repo https://dl.gitea.io/charts  \
  gitea \
  --version 10.6.0 \
  --namepace gitea \
  --create-namespace \
  --values values-gitea.yaml
```

The content of `values-gitea.yaml`
```
service:
  http:
    clusterIP:
  ssh:
    clusterIP:
    port: 2222
    targetPort: 2222
```