### PR TITLE
feat: Allow passing extra arguments to cloudflared

### DIFF
--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -29,6 +29,7 @@ type rootCmdFlags struct {
 	cloudflareTunnelName string
 	namespace            string
 	cloudflaredProtocol  string
+	cloudflaredExtraArgs string
 }
 
 func main() {
@@ -41,6 +42,7 @@ func main() {
 		logLevel:            0,
 		namespace:           "default",
 		cloudflaredProtocol: "auto",
+		cloudflaredExtraArgs: os.Getenv("CONTROLLER_CLOUDFLARED_EXTRA_ARGS"),
 	}
 
 	crlog.SetLogger(rootLogger.WithName("controller-runtime"))
@@ -102,7 +104,7 @@ func main() {
 					case <-done:
 						return
 					case _ = <-ticker.C:
-						err := controller.CreateOrUpdateControlledCloudflared(ctx, mgr.GetClient(), tunnelClient, options.namespace, options.cloudflaredProtocol)
+						err := controller.CreateOrUpdateControlledCloudflared(ctx, mgr.GetClient(), tunnelClient, options.namespace, options.cloudflaredProtocol, options.cloudflaredExtraArgs)
 						if err != nil {
 							logger.WithName("controlled-cloudflared").Error(err, "create controlled cloudflared")
 						}
@@ -123,6 +125,7 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.cloudflareTunnelName, "cloudflare-tunnel-name", options.cloudflareTunnelName, "cloudflare tunnel name")
 	rootCommand.PersistentFlags().StringVar(&options.namespace, "namespace", options.namespace, "namespace to execute cloudflared connector")
 	rootCommand.PersistentFlags().StringVar(&options.cloudflaredProtocol, "cloudflared-protocol", options.cloudflaredProtocol, "cloudflared protocol")
+	rootCommand.PersistentFlags().StringVar(&options.cloudflaredExtraArgs, "cloudflared-extra-args", options.cloudflaredExtraArgs, "Comma-separated extra arguments for cloudflared")
 
 	err := rootCommand.Execute()
 	if err != nil {

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.cloudflared.image.pullPolicy | quote }}
             - name: CLOUDFLARED_REPLICA_COUNT
               value: {{ .Values.cloudflared.replicaCount | quote }}
+            - name: CONTROLLER_CLOUDFLARED_EXTRA_ARGS
+              value: {{ .Values.cloudflared.extraArgs | join "," | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -80,6 +80,7 @@ cloudflared:
     tag: latest
   replicaCount: 1
   protocol: auto
+  extraArgs: []
 
 cloudflaredServiceMonitor:
   create: false


### PR DESCRIPTION
This change introduces the ability for you to specify additional command-line arguments for the cloudflared daemon managed by the ingress controller.

Modifications:

-   `helm/cloudflare-tunnel-ingress-controller/values.yaml`:
    Added `cloudflared.extraArgs` (list of strings) to allow you
    to define extra arguments via Helm values.
-   `helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml`:
    The controller's deployment now reads `cloudflared.extraArgs` and
    passes them as a comma-separated string in the
    `CONTROLLER_CLOUDFLARED_EXTRA_ARGS` environment variable to the
    controller pod.
-   `cmd/cloudflare-tunnel-ingress-controller/main.go`:
    The controller now accepts a `--cloudflared-extra-args` flag and
    reads the `CONTROLLER_CLOUDFLARED_EXTRA_ARGS` environment variable
    to get the extra arguments. These are then passed to the
    cloudflared connector logic.
-   `pkg/controller/controlled-cloudflared-connector.go`:
    The `cloudflaredConnectDeploymentTemplating` function now accepts
    the extra arguments string, splits it, and appends the arguments
    to the cloudflared container's command.

This allows you to customize cloudflared's behavior further, for example, by enabling features like `--loglevel debug` or specifying different connection parameters if needed.