### PR TITLE
feat: use FQDN service names instead of cluster IPs for Cloudflare tunnel configuration

### DIFF
--- a/pkg/exposure/exposure.go
+++ b/pkg/exposure/exposure.go
@@ -4,7 +4,7 @@ package exposure
 type Exposure struct {
 	// Hostname is the domain name to expose the service, eg. hello.strrl.dev
 	Hostname string
-	// ServiceTarget is the url of the service to expose, eg. http://10.109.94.106:9117
+	// ServiceTarget is the url of the service to expose, eg. http://my-service.default.svc.cluster.local:9117
 	ServiceTarget string
 	// PathPrefix is the path prefix to expose the service, eg. /hello
 	PathPrefix string

--- a/test/integration/controller/ingress_transform_test.go
+++ b/test/integration/controller/ingress_transform_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -102,7 +103,8 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
 		Expect(exposure[0].Hostname).Should(Equal("test.example.com"))
-		Expect(exposure[0].ServiceTarget).Should(Equal("http://10.0.0.23:2333"))
+		expectedTarget := fmt.Sprintf("http://%s.%s.svc.cluster.local:2333", service.Name, ns)
+		Expect(exposure[0].ServiceTarget).Should(Equal(expectedTarget))
 		Expect(exposure[0].PathPrefix).Should(Equal("/"))
 		Expect(exposure[0].IsDeleted).Should(BeFalse())
 	})
@@ -341,7 +343,8 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
 		Expect(exposure[0].Hostname).Should(Equal("test.example.com"))
-		Expect(exposure[0].ServiceTarget).Should(Equal("http://10.0.0.26:2333"))
+		expectedTarget := fmt.Sprintf("http://%s.%s.svc.cluster.local:2333", service.Name, ns)
+		Expect(exposure[0].ServiceTarget).Should(Equal(expectedTarget))
 		Expect(exposure[0].PathPrefix).Should(Equal("/"))
 		Expect(exposure[0].IsDeleted).Should(BeFalse())
 	})
@@ -583,7 +586,8 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
 		Expect(exposure[0].Hostname).Should(Equal("test.example.com"))
-		Expect(exposure[0].ServiceTarget).Should(Equal("https://10.0.0.27:2333"))
+		expectedTarget := fmt.Sprintf("https://%s.%s.svc.cluster.local:2333", service.Name, ns)
+		Expect(exposure[0].ServiceTarget).Should(Equal(expectedTarget))
 		Expect(exposure[0].PathPrefix).Should(Equal("/"))
 		Expect(exposure[0].IsDeleted).Should(BeFalse())
 		Expect(exposure[0].ProxySSLVerifyEnabled).Should(BeNil())
@@ -671,7 +675,8 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
 		Expect(exposure[0].Hostname).Should(Equal("test.example.com"))
-		Expect(exposure[0].ServiceTarget).Should(Equal("https://10.0.0.28:2333"))
+		expectedTarget := fmt.Sprintf("https://%s.%s.svc.cluster.local:2333", service.Name, ns)
+		Expect(exposure[0].ServiceTarget).Should(Equal(expectedTarget))
 		Expect(exposure[0].PathPrefix).Should(Equal("/"))
 		Expect(exposure[0].IsDeleted).Should(BeFalse())
 		Expect(exposure[0].ProxySSLVerifyEnabled).ShouldNot(BeNil())
@@ -760,7 +765,8 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
 		Expect(exposure[0].Hostname).Should(Equal("test.example.com"))
-		Expect(exposure[0].ServiceTarget).Should(Equal("https://10.0.0.29:2333"))
+		expectedTarget := fmt.Sprintf("https://%s.%s.svc.cluster.local:2333", service.Name, ns)
+		Expect(exposure[0].ServiceTarget).Should(Equal(expectedTarget))
 		Expect(exposure[0].PathPrefix).Should(Equal("/"))
 		Expect(exposure[0].IsDeleted).Should(BeFalse())
 		Expect(exposure[0].ProxySSLVerifyEnabled).ShouldNot(BeNil())


### PR DESCRIPTION
This change improves stability by using service FQDN names instead of cluster IPs when configuring Cloudflare tunnel exposures.

Changes:
- Modified getHostFromService() to return FQDN service names
- Updated tests to reflect the new behavior
- Updated documentation comments

Fixes #213

Generated with [Claude Code](https://claude.ai/code)