### PR TITLE
feat: add custom labels support to ServiceMonitor

### DIFF
--- a/helm/cloudflare-tunnel-ingress-controller/templates/controlled-cloudflared-servicemonitor.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/controlled-cloudflared-servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "cloudflare-tunnel-ingress-controller.fullname" . }}-controlled-cloudflared
   labels:
     {{- include "cloudflare-tunnel-ingress-controller.labels" . | nindent 4 }}
+    {{- if .Values.cloudflaredServiceMonitor.labels }}
+    {{- toYaml .Values.cloudflaredServiceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.cloudflaredServiceMonitor.jobLabel }}
   jobLabel: {{ .Values.cloudflaredServiceMonitor.jobLabel }}


### PR DESCRIPTION
Allow users to add custom labels to the ServiceMonitor resource via cloudflaredServiceMonitor.labels in values.yaml. This enables compatibility with Prometheus Operator instances that use custom label selectors.

Example usage:
```yaml
cloudflaredServiceMonitor:
  create: true
  labels:
    release: kube-prometheus-stack
```

This change maintains backward compatibility - if no custom labels are specified, the ServiceMonitor behaves exactly as before.