### PR TITLE
ci: remove GitHub Actions cache from container image builds

### DIFF
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -57,8 +57,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ needs.metadata.outputs.owner }}/cloudflare-tunnel-ingress-controller:${{ needs.metadata.outputs.version }}-amd64
           labels: ${{ needs.metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   build-arm64:
     needs: metadata
@@ -87,8 +85,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ needs.metadata.outputs.owner }}/cloudflare-tunnel-ingress-controller:${{ needs.metadata.outputs.version }}-arm64
           labels: ${{ needs.metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   create-manifest:
     needs: [metadata, build-amd64, build-arm64]


### PR DESCRIPTION
Remove cache-from and cache-to configuration from both amd64 and arm64 build jobs to avoid dependency on GitHub Actions cache and gcloud authentication requirements.