### PR TITLE
fix(docker): bump Go version in Dockerfile to 1.25

### DIFF
--- a/image/cloudflare-tunnel-ingress-controller/Dockerfile
+++ b/image/cloudflare-tunnel-ingress-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary
- Bumps the Go builder image in the Dockerfile from `golang:1.24` to `golang:1.25` to match the `go 1.25.0` requirement in `go.mod`
- Fixes the e2e-test CI failure: `go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`

## Test plan
- [ ] Verify e2e-test CI job passes with the updated Dockerfile