### PR TITLE
feat: add validation and case-insensitive handling for backend-protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Pre-commit hooks are managed via [prek](https://prek.j178.dev/) (configured in `
 
 ### Supported Annotations
 - `cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify`: Enable/disable SSL verification ("on" or "off", default: "off")
-- `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol`: Backend protocol (default: "http")
+- `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol`: Backend protocol, "http" or "https" (default: "http", case-insensitive)
 - `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`: Set HTTP Host header for the local webserver
 - `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`: Hostname on the origin server certificate
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,53 @@ kubectl -n kubernetes-dashboard \
 
 - Done! Enjoy! 🎉
 
+## Annotations
+
+The following annotations can be used on Ingress resources to configure backend behavior:
+
+| Annotation | Description | Values | Default |
+|---|---|---|---|
+| `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol` | Protocol for connecting to the backend service | `http`, `https` (case-insensitive) | `http` |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify` | Enable TLS certificate verification for HTTPS backends | `on`, `off` | `off` |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name` | Hostname on the origin server certificate (for TLS SNI) | any hostname | - |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header` | Override the HTTP Host header sent to the backend | any hostname | - |
+
+### HTTPS Backend
+
+If your backend service terminates TLS (e.g., a pod running nginx with HTTPS), set the `backend-protocol` annotation to `https`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-https-backend
+  annotations:
+    cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: "https"
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: myapp.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 443
+```
+
+By default, TLS certificate verification is disabled (`NoTLSVerify: true`) for HTTPS backends, which is suitable for self-signed certificates. To enable verification, use the `proxy-ssl-verify` and `origin-server-name` annotations:
+
+```yaml
+metadata:
+  annotations:
+    cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: "https"
+    cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify: "on"
+    cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name: "my-service.internal"
+```
+
 ## Alternative
 
 There is also an awesome project which could integrate with Cloudflare Tunnel as CRD, check it out [adyanth/cloudflare-operator](https://github.com/adyanth/cloudflare-operator)!

--- a/pkg/controller/weel_known_annotations.go
+++ b/pkg/controller/weel_known_annotations.go
@@ -5,7 +5,8 @@ const AnnotationProxySSLVerify = "cloudflare-tunnel-ingress-controller.strrl.dev
 const AnnotationProxySSLVerifyOn = "on"
 const AnnotationProxySSLVerifyOff = "off"
 
-// AnnotationBackendProtocol is the annotation key for proxy-backend-protocol, default "http".
+// AnnotationBackendProtocol is the annotation key for backend-protocol.
+// Available values: "http" or "https" (case-insensitive), default "http".
 const AnnotationBackendProtocol = "cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol"
 
 // AnnotationHTTPHostHeader is to set the HTTP Host header for the local webserver.


### PR DESCRIPTION
## Summary
Resolves https://github.com/STRRL/cloudflare-tunnel-ingress-controller/issues/145

Adds validation and case-insensitive handling for the `backend-protocol` annotation. Users coming from nginx can now use uppercase `HTTPS` (as in `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"`), and invalid values like `ftp` are rejected with a clear error message.

- Normalizes annotation value to lowercase so `HTTPS`, `Https`, etc. all work
- Validates that only `http` or `https` are accepted
- Adds unit and integration tests covering edge cases
- Documents the feature in README with usage examples

## Test Plan
- All unit tests pass (12 tests in cloudflare-controller transform)
- 2 new unit tests: HTTPS with all options combined, HTTP backend TLS option isolation
- 2 new integration tests: uppercase normalization, invalid protocol rejection
- Pre-commit hooks (gofmt, vet, golangci-lint) pass