### PR TITLE
feat: add leader election support for high availability

### DIFF
--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             {{- range .Values.cloudflared.extraArgs }}
             - --cloudflared-extra-args={{ . }}
             {{- end }}
+            {{- if .Values.leaderElection.enabled }}
+            - --leader-elect
+            {{- end }}
           env:
             - name: CLOUDFLARE_API_TOKEN
               valueFrom:

--- a/helm/cloudflare-tunnel-ingress-controller/templates/role.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/role.yaml
@@ -15,3 +15,22 @@ rules:
       - watch
       - update
       - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/helm/cloudflare-tunnel-ingress-controller/templates/rulebinding.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/rulebinding.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "cloudflare-tunnel-ingress-controller.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "cloudflare-tunnel-ingress-controller.fullname" . }}-controlled-cloudflared-connector
 subjects:
   - name: {{ include "cloudflare-tunnel-ingress-controller.serviceAccountName" . }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -80,6 +80,10 @@ affinity: {}
 # (e.g. <service>.<namespace>.svc.<clusterDomain>).
 # This should match the kubelet --cluster-domain flag (default: "cluster.local").
 clusterDomain: cluster.local
+
+leaderElection:
+  enabled: false
+
 cloudflared:
   image:
     repository: cloudflare/cloudflared


### PR DESCRIPTION
## Summary

Implements #130: Enable leader election for multi-replica deployments. Controller-runtime's built-in leader election ensures only one instance actively reconciles resources, preventing race conditions on Cloudflare tunnel configuration updates.

## Changes

- **Go**: Added `--leader-elect` flag, configured manager with `LeaderElection` options, and gated the cloudflared connector loop on `mgr.Elected()` channel
- **Helm**: Added `leaderElection.enabled` configuration and conditional flag in deployment template
- **RBAC**: Added permissions for `coordination.k8s.io/leases` and events; fixed pre-existing RoleBinding/Role kind mismatch
- **Backward compatible**: Leader election is disabled by default

## Testing

- Unit tests pass
- Build succeeds
- Helm templates render correctly with both `leaderElection.enabled: true` and `false`