### PR TITLE
feat: add configurable DNS comment template for CNAME records

### DIFF
--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -33,6 +33,7 @@ type rootCmdFlags struct {
 	cloudflaredExtraArgs []string
 	clusterDomain        string
 	leaderElect          bool
+	dnsCommentTemplate   string
 }
 
 func main() {
@@ -48,6 +49,7 @@ func main() {
 		namespace:           "default",
 		cloudflaredProtocol: "auto",
 		clusterDomain:       "cluster.local",
+		dnsCommentTemplate:  "managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]",
 	}
 
 	crlog.SetLogger(rootLogger.WithName("controller-runtime"))
@@ -70,7 +72,7 @@ func main() {
 			var tunnelClient *cloudflarecontroller.TunnelClient
 
 			logger.V(3).Info("bootstrap tunnel client with tunnel name", "account-id", options.cloudflareAccountId, "tunnel-name", options.cloudflareTunnelName)
-			tunnelClient, err = cloudflarecontroller.BootstrapTunnelClientWithTunnelName(ctx, logger.WithName("tunnel-client"), cloudflareClient, options.cloudflareAccountId, options.cloudflareTunnelName)
+			tunnelClient, err = cloudflarecontroller.BootstrapTunnelClientWithTunnelName(ctx, logger.WithName("tunnel-client"), cloudflareClient, options.cloudflareAccountId, options.cloudflareTunnelName, options.dnsCommentTemplate)
 			if err != nil {
 				logger.Error(err, "bootstrap tunnel client with tunnel name")
 				os.Exit(1)
@@ -145,6 +147,7 @@ func main() {
 	rootCommand.PersistentFlags().StringSliceVar(&options.cloudflaredExtraArgs, "cloudflared-extra-args", options.cloudflaredExtraArgs, "extra arguments to pass to cloudflared")
 	rootCommand.PersistentFlags().StringVar(&options.clusterDomain, "cluster-domain", options.clusterDomain, "kubernetes cluster domain, used to build service FQDN (should match kubelet --cluster-domain)")
 	rootCommand.PersistentFlags().BoolVar(&options.leaderElect, "leader-elect", options.leaderElect, "enable leader election for high availability")
+	rootCommand.PersistentFlags().StringVar(&options.dnsCommentTemplate, "dns-comment-template", options.dnsCommentTemplate, "Go template for DNS record comments. Available variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}. Set to empty string to disable. Note: Cloudflare limits comment length by plan (Free: 100, Pro/Biz/Ent: 500 chars). See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/")
 
 	err := rootCommand.Execute()
 	if err != nil {

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - --namespace=$(NAMESPACE)
             - --cloudflared-protocol={{ .Values.cloudflared.protocol }}
             - --cluster-domain={{ .Values.clusterDomain | default "cluster.local" }}
+            - --dns-comment-template={{ .Values.dnsCommentTemplate | default "" }}
             {{- range .Values.cloudflared.extraArgs }}
             - --cloudflared-extra-args={{ . }}
             {{- end }}

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - --namespace=$(NAMESPACE)
             - --cloudflared-protocol={{ .Values.cloudflared.protocol }}
             - --cluster-domain={{ .Values.clusterDomain | default "cluster.local" }}
-            - --dns-comment-template={{ .Values.dnsCommentTemplate | default "" }}
+            - "--dns-comment-template={{ .Values.dnsCommentTemplate | default "" }}"
             {{- range .Values.cloudflared.extraArgs }}
             - --cloudflared-extra-args={{ . }}
             {{- end }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -79,6 +79,7 @@ affinity: {}
 # Kubernetes cluster domain, used to construct FQDN for services
 # (e.g. <service>.<namespace>.svc.<clusterDomain>).
 # This should match the kubelet --cluster-domain flag (default: "cluster.local").
+
 # Go template for DNS CNAME record comments. This is purely informational and
 # does NOT affect record ownership (which is tracked via TXT records).
 # Available template variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -79,6 +79,17 @@ affinity: {}
 # Kubernetes cluster domain, used to construct FQDN for services
 # (e.g. <service>.<namespace>.svc.<clusterDomain>).
 # This should match the kubelet --cluster-domain flag (default: "cluster.local").
+# Go template for DNS CNAME record comments. This is purely informational and
+# does NOT affect record ownership (which is tracked via TXT records).
+# Available template variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}
+# Set to empty string "" to disable comments entirely.
+#
+# Note: Cloudflare enforces comment length limits per plan:
+#   Free: 100 chars | Pro/Business/Enterprise: 500 chars
+# If the rendered comment exceeds your plan's limit, the Cloudflare API will reject it.
+# See: https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/
+dnsCommentTemplate: "managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]"
+
 clusterDomain: cluster.local
 
 leaderElection:

--- a/pkg/cloudflare-controller/bootstrap.go
+++ b/pkg/cloudflare-controller/bootstrap.go
@@ -11,14 +11,14 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func BootstrapTunnelClientWithTunnelName(ctx context.Context, logger logr.Logger, cfClient *cloudflare.API, accountId string, tunnelName string) (*TunnelClient, error) {
+func BootstrapTunnelClientWithTunnelName(ctx context.Context, logger logr.Logger, cfClient *cloudflare.API, accountId string, tunnelName string, dnsCommentTemplate string) (*TunnelClient, error) {
 	logger.V(3).Info("fetch tunnel id with tunnel name", "account-id", accountId, "tunnel-name", tunnelName)
 	tunnelId, err := GetTunnelIdFromTunnelName(ctx, logger, cfClient, tunnelName, accountId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get tunnel id from tunnel name %s", tunnelName)
 	}
 	logger.V(3).Info("tunnel id fetched", "tunnel-id", tunnelId, "tunnel-name", tunnelName, "account-id", accountId)
-	return NewTunnelClient(logger, cfClient, accountId, tunnelId, tunnelName), nil
+	return NewTunnelClient(logger, cfClient, accountId, tunnelId, tunnelName, dnsCommentTemplate), nil
 }
 
 func GetTunnelIdFromTunnelName(ctx context.Context, logger logr.Logger, cfClient *cloudflare.API, tunnelName string, accountId string) (string, error) {

--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -1,10 +1,12 @@
 package cloudflarecontroller
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"slices"
 	"strings"
+	"text/template"
 
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
 	"github.com/cloudflare/cloudflare-go"
@@ -21,15 +23,73 @@ type TunnelClientInterface interface {
 var _ TunnelClientInterface = &TunnelClient{}
 
 type TunnelClient struct {
-	logger     logr.Logger
-	cfClient   *cloudflare.API
-	accountId  string
-	tunnelId   string
-	tunnelName string
+	logger              logr.Logger
+	cfClient            *cloudflare.API
+	accountId           string
+	tunnelId            string
+	tunnelName          string
+	dnsCommentTemplate  *template.Template // nil if disabled (empty template string)
+	dnsCommentTemplateS string             // raw template string for logging
 }
 
-func NewTunnelClient(logger logr.Logger, cfClient *cloudflare.API, accountId string, tunnelId string, tunnelName string) *TunnelClient {
-	return &TunnelClient{logger: logger, cfClient: cfClient, accountId: accountId, tunnelId: tunnelId, tunnelName: tunnelName}
+// DNSCommentTemplateData contains the variables available in the DNS comment template.
+// See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/
+// for comment length limits per Cloudflare plan (Free: 100, Pro/Business/Enterprise: 500 chars).
+type DNSCommentTemplateData struct {
+	TunnelName string // Name of the Cloudflare Tunnel
+	TunnelId   string // ID of the Cloudflare Tunnel
+	Hostname   string // DNS record hostname (e.g. "app.example.com")
+}
+
+func NewTunnelClient(logger logr.Logger, cfClient *cloudflare.API, accountId string, tunnelId string, tunnelName string, dnsCommentTemplate string) *TunnelClient {
+	tc := &TunnelClient{
+		logger:              logger,
+		cfClient:            cfClient,
+		accountId:           accountId,
+		tunnelId:            tunnelId,
+		tunnelName:          tunnelName,
+		dnsCommentTemplateS: dnsCommentTemplate,
+	}
+	if dnsCommentTemplate != "" {
+		tmpl, err := template.New("dns-comment").Parse(dnsCommentTemplate)
+		if err != nil {
+			logger.Error(err, "failed to parse dns-comment-template, DNS comments will be disabled", "template", dnsCommentTemplate)
+		} else {
+			tc.dnsCommentTemplate = tmpl
+		}
+	}
+	return tc
+}
+
+// renderDNSComment renders the DNS comment for a given hostname using the configured template.
+// Returns empty string if the template is disabled or rendering fails.
+func (t *TunnelClient) renderDNSComment(hostname string) string {
+	if t.dnsCommentTemplate == nil {
+		return ""
+	}
+	data := DNSCommentTemplateData{
+		TunnelName: t.tunnelName,
+		TunnelId:   t.tunnelId,
+		Hostname:   hostname,
+	}
+	var buf bytes.Buffer
+	if err := t.dnsCommentTemplate.Execute(&buf, data); err != nil {
+		t.logger.Error(err, "failed to render dns comment template", "hostname", hostname)
+		return ""
+	}
+	comment := buf.String()
+
+	// Warn about comment length.
+	// Cloudflare enforces per-plan limits: Free=100, Pro/Business/Enterprise=500 chars.
+	// See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/
+	if len(comment) > 100 {
+		t.logger.Info("WARNING: rendered DNS comment exceeds 100 characters (Cloudflare Free plan limit). "+
+			"Pro/Business/Enterprise plans allow up to 500 characters. "+
+			"If your plan does not support this length, the API call may fail.",
+			"hostname", hostname, "commentLength", len(comment),
+		)
+	}
+	return comment
 }
 
 func (t *TunnelClient) PutExposures(ctx context.Context, exposures []exposure.Exposure) error {
@@ -176,13 +236,22 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 
 	for _, item := range toCreate {
 		t.logger.Info("create DNS record", "type", item.Type, "hostname", item.Hostname, "content", item.Content)
-		_, err := t.cfClient.CreateDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), cloudflare.CreateDNSRecordParams{
+		params := cloudflare.CreateDNSRecordParams{
 			Type:    item.Type,
 			Name:    item.Hostname,
 			Content: item.Content,
 			Proxied: cloudflare.BoolPtr(item.Type == "CNAME"),
 			TTL:     1,
-		})
+		}
+		// Add comment to CNAME records if template is configured.
+		// Comments are informational only; ownership is tracked via TXT records.
+		// See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/
+		if item.Type == "CNAME" {
+			if comment := t.renderDNSComment(item.Hostname); comment != "" {
+				params.Comment = comment
+			}
+		}
+		_, err := t.cfClient.CreateDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), params)
 		if err != nil {
 			return errors.Wrapf(err, "create DNS record for zone %s, hostname %s", zone.Name, item.Hostname)
 		}
@@ -190,14 +259,21 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 
 	for _, item := range toUpdate {
 		t.logger.Info("update DNS record", "id", item.OldRecord.ID, "type", item.Type, "hostname", item.OldRecord.Name, "content", item.Content)
-		_, err := t.cfClient.UpdateDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), cloudflare.UpdateDNSRecordParams{
+		params := cloudflare.UpdateDNSRecordParams{
 			ID:      item.OldRecord.ID,
 			Type:    item.Type,
 			Name:    item.OldRecord.Name,
 			Content: item.Content,
 			Proxied: cloudflare.BoolPtr(item.Type == "CNAME"),
 			TTL:     1,
-		})
+		}
+		// Add comment to CNAME records if template is configured.
+		if item.Type == "CNAME" {
+			if comment := t.renderDNSComment(item.OldRecord.Name); comment != "" {
+				params.Comment = &comment
+			}
+		}
+		_, err := t.cfClient.UpdateDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), params)
 		if err != nil {
 			return errors.Wrapf(err, "update DNS record for zone %s, hostname %s", zone.Name, item.OldRecord.Name)
 		}

--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -23,13 +23,12 @@ type TunnelClientInterface interface {
 var _ TunnelClientInterface = &TunnelClient{}
 
 type TunnelClient struct {
-	logger              logr.Logger
-	cfClient            *cloudflare.API
-	accountId           string
-	tunnelId            string
-	tunnelName          string
-	dnsCommentTemplate  *template.Template // nil if disabled (empty template string)
-	dnsCommentTemplateS string             // raw template string for logging
+	logger             logr.Logger
+	cfClient           *cloudflare.API
+	accountId          string
+	tunnelId           string
+	tunnelName         string
+	dnsCommentTemplate *template.Template // nil if disabled (empty template string)
 }
 
 // DNSCommentTemplateData contains the variables available in the DNS comment template.
@@ -43,12 +42,11 @@ type DNSCommentTemplateData struct {
 
 func NewTunnelClient(logger logr.Logger, cfClient *cloudflare.API, accountId string, tunnelId string, tunnelName string, dnsCommentTemplate string) *TunnelClient {
 	tc := &TunnelClient{
-		logger:              logger,
-		cfClient:            cfClient,
-		accountId:           accountId,
-		tunnelId:            tunnelId,
-		tunnelName:          tunnelName,
-		dnsCommentTemplateS: dnsCommentTemplate,
+		logger:     logger,
+		cfClient:   cfClient,
+		accountId:  accountId,
+		tunnelId:   tunnelId,
+		tunnelName: tunnelName,
 	}
 	if dnsCommentTemplate != "" {
 		tmpl, err := template.New("dns-comment").Parse(dnsCommentTemplate)
@@ -83,9 +81,7 @@ func (t *TunnelClient) renderDNSComment(hostname string) string {
 	// Cloudflare enforces per-plan limits: Free=100, Pro/Business/Enterprise=500 chars.
 	// See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/
 	if len(comment) > 100 {
-		t.logger.Info("WARNING: rendered DNS comment exceeds 100 characters (Cloudflare Free plan limit). "+
-			"Pro/Business/Enterprise plans allow up to 500 characters. "+
-			"If your plan does not support this length, the API call may fail.",
+		t.logger.Info("rendered DNS comment exceeds 100 characters (Cloudflare Free plan limit, Pro/Business/Enterprise allow 500)",
 			"hostname", hostname, "commentLength", len(comment),
 		)
 	}

--- a/pkg/cloudflare-controller/tunnel_client_test.go
+++ b/pkg/cloudflare-controller/tunnel_client_test.go
@@ -1,0 +1,94 @@
+package cloudflarecontroller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestRenderDNSComment(t *testing.T) {
+	tests := []struct {
+		name              string
+		templateStr       string
+		hostname          string
+		tunnelName        string
+		tunnelId          string
+		wantContains      string
+		wantEmpty         bool
+		wantLengthOver100 bool
+	}{
+		{
+			name:        "empty template disables comments",
+			templateStr: "",
+			hostname:    "app.example.com",
+			wantEmpty:   true,
+		},
+		{
+			name:         "default template renders correctly",
+			templateStr:  "managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]",
+			hostname:     "app.example.com",
+			tunnelName:   "my-tunnel",
+			tunnelId:     "abc-123",
+			wantContains: "managed by cloudflare-tunnel-ingress-controller, tunnel [my-tunnel]",
+		},
+		{
+			name:         "template with all variables",
+			templateStr:  "tunnel={{.TunnelName}} id={{.TunnelId}} host={{.Hostname}}",
+			hostname:     "app.example.com",
+			tunnelName:   "my-tunnel",
+			tunnelId:     "abc-123",
+			wantContains: "tunnel=my-tunnel id=abc-123 host=app.example.com",
+		},
+		{
+			name:         "template with only hostname",
+			templateStr:  "record for {{.Hostname}}",
+			hostname:     "sub.domain.example.com",
+			tunnelName:   "t",
+			tunnelId:     "id",
+			wantContains: "record for sub.domain.example.com",
+		},
+		{
+			name:              "long comment exceeds 100 chars",
+			templateStr:       "this is a very long comment template that will definitely exceed one hundred characters when rendered with tunnel={{.TunnelName}}",
+			hostname:          "app.example.com",
+			tunnelName:        "my-long-tunnel-name",
+			tunnelId:          "abc-123",
+			wantLengthOver100: true,
+		},
+		{
+			name:        "invalid template syntax degrades gracefully",
+			templateStr: "{{.InvalidSyntax",
+			hostname:    "app.example.com",
+			wantEmpty:   true,
+		},
+		{
+			name:         "static template without variables",
+			templateStr:  "managed by controller",
+			hostname:     "app.example.com",
+			tunnelName:   "t",
+			tunnelId:     "id",
+			wantContains: "managed by controller",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := NewTunnelClient(logr.Discard(), nil, "acc", tt.tunnelId, tt.tunnelName, tt.templateStr)
+			got := tc.renderDNSComment(tt.hostname)
+
+			if tt.wantEmpty && got != "" {
+				t.Errorf("expected empty comment, got %q", got)
+			}
+			if tt.wantContains != "" && got != tt.wantContains {
+				t.Errorf("expected %q, got %q", tt.wantContains, got)
+			}
+			if tt.wantLengthOver100 && len(got) <= 100 {
+				t.Errorf("expected comment length > 100, got %d: %q", len(got), got)
+			}
+			if !tt.wantEmpty && tt.wantContains != "" && strings.TrimSpace(got) == "" {
+				t.Errorf("expected non-empty comment, got empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Restores DNS CNAME record comments that were removed when ownership tracking migrated from comment-based to TXT-based. Closes #274.

## Changes

- **New CLI flag**: `--dns-comment-template` — a Go template rendered into the `Comment` field of DNS CNAME records.
- **New Helm value**: `dnsCommentTemplate` with the same behavior.
- **Default template**: `managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]` (matches the old comment format).
- **Available template variables**: `{{.TunnelName}}`, `{{.TunnelId}}`, `{{.Hostname}}`.
- **Disable**: set to empty string `""` to skip setting comments entirely.
- **Length warning**: logs a warning when the rendered comment exceeds 100 characters (Cloudflare Free plan limit). Pro/Business/Enterprise plans allow up to 500 characters. See [Cloudflare docs](https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/).

## Notes

- Comments are purely informational. Record ownership is still tracked via `_ctic_managed` TXT records.
- Template parse errors are logged and gracefully degraded (no comment set, no crash).
- All existing unit tests pass.

## Files Changed

| File | Change |
|------|--------|
| `cmd/.../main.go` | New `--dns-comment-template` flag |
| `pkg/.../bootstrap.go` | Pass template to TunnelClient |
| `pkg/.../tunnel-client.go` | Template rendering + length warning + Comment in Create/Update |
| `helm/.../values.yaml` | New `dnsCommentTemplate` value with docs |
| `helm/.../deployment.yaml` | Pass flag to container |