### PR TITLE
feat: add bypass, session-duration, and auto-redirect annotations

### DIFF
--- a/pkg/cloudflare-controller/access.go
+++ b/pkg/cloudflare-controller/access.go
@@ -30,11 +30,16 @@ func hostnameFromAccessAppName(name, tunnelName string) string {
 	return strings.TrimPrefix(name, prefix)
 }
 
+const defaultSessionDuration = "24h"
+
 // desiredAccessApp holds the desired state for an Access Application on a given hostname.
 // Group fields contain names from annotations; IDs are resolved at reconcile time.
 type desiredAccessApp struct {
 	AllowedGroupIDs []string
 	DeniedGroupIDs  []string
+	Bypass          bool
+	SessionDuration string
+	AutoRedirect    *bool
 }
 
 // resolveGroupNames maps group names to IDs using the provided lookup map.
@@ -59,19 +64,30 @@ func desiredAccessApps(exposures []exposure.Exposure) map[string]desiredAccessAp
 		if e.IsDeleted {
 			continue
 		}
-		if len(e.AllowedAccessGroupIDs) == 0 && len(e.DeniedAccessGroupIDs) == 0 {
+
+		hasGroups := len(e.AllowedAccessGroupIDs) > 0 || len(e.DeniedAccessGroupIDs) > 0
+		if !hasGroups && !e.AccessBypass {
 			continue
 		}
 
 		existing := result[e.Hostname]
 		existing.AllowedGroupIDs = unionStrings(existing.AllowedGroupIDs, e.AllowedAccessGroupIDs)
 		existing.DeniedGroupIDs = unionStrings(existing.DeniedGroupIDs, e.DeniedAccessGroupIDs)
+		if e.AccessBypass {
+			existing.Bypass = true
+		}
+		if e.AccessSessionDuration != "" {
+			existing.SessionDuration = e.AccessSessionDuration
+		}
+		if e.AccessAutoRedirect != nil {
+			existing.AutoRedirect = e.AccessAutoRedirect
+		}
 		result[e.Hostname] = existing
 	}
 
-	// Remove entries with no allowed groups — deny-only doesn't make sense without an allow
+	// Remove entries with no allowed groups and no bypass
 	for hostname, app := range result {
-		if len(app.AllowedGroupIDs) == 0 {
+		if len(app.AllowedGroupIDs) == 0 && !app.Bypass {
 			delete(result, hostname)
 		}
 	}
@@ -155,10 +171,10 @@ func (t *TunnelClient) updateAccessApplications(ctx context.Context, exposures [
 				return errors.Wrapf(err, "create access application for %s", hostname)
 			}
 		} else {
-			t.logger.V(3).Info("update access application policies", "hostname", hostname, "app-id", existingApp.ID)
-			err := t.updateAccessAppPolicies(ctx, rc, existingApp, want)
+			t.logger.V(3).Info("update access application", "hostname", hostname, "app-id", existingApp.ID)
+			err := t.updateAccessApp(ctx, rc, existingApp, want)
 			if err != nil {
-				return errors.Wrapf(err, "update access application policies for %s", hostname)
+				return errors.Wrapf(err, "update access application for %s", hostname)
 			}
 		}
 	}
@@ -177,19 +193,43 @@ func (t *TunnelClient) updateAccessApplications(ctx context.Context, exposures [
 	return nil
 }
 
-// createAccessApp creates an Access Application and its allow (and optionally deny) policies.
+// createAccessApp creates an Access Application and its policies.
 func (t *TunnelClient) createAccessApp(ctx context.Context, rc *cloudflare.ResourceContainer, hostname string, want desiredAccessApp) error {
-	app, err := t.cfClient.CreateAccessApplication(ctx, rc, cloudflare.CreateAccessApplicationParams{
+	sessionDuration := defaultSessionDuration
+	if want.SessionDuration != "" {
+		sessionDuration = want.SessionDuration
+	}
+
+	params := cloudflare.CreateAccessApplicationParams{
 		Name:            accessAppName(t.tunnelName, hostname),
 		Domain:          hostname,
 		Type:            cloudflare.SelfHosted,
-		SessionDuration: "24h",
-	})
+		SessionDuration: sessionDuration,
+	}
+	if want.AutoRedirect != nil {
+		params.AutoRedirectToIdentity = want.AutoRedirect
+	}
+
+	app, err := t.cfClient.CreateAccessApplication(ctx, rc, params)
 	if err != nil {
 		return errors.Wrap(err, "create access application")
 	}
 
-	// Create allow policy (precedence 1 = evaluated first by default, but deny at precedence 1 takes priority)
+	if want.Bypass {
+		_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
+			ApplicationID: app.ID,
+			Name:          "bypass",
+			Decision:      "bypass",
+			Precedence:    1,
+			Include:       []interface{}{cloudflare.AccessGroupEveryone{}},
+		})
+		if err != nil {
+			return errors.Wrap(err, "create bypass policy")
+		}
+		return nil
+	}
+
+	// Create allow policy
 	_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
 		ApplicationID: app.ID,
 		Name:          "allow",
@@ -201,7 +241,7 @@ func (t *TunnelClient) createAccessApp(ctx context.Context, rc *cloudflare.Resou
 		return errors.Wrap(err, "create allow policy")
 	}
 
-	// Create deny policy if deny groups are specified (higher precedence = evaluated first)
+	// Create deny policy if deny groups are specified
 	if len(want.DeniedGroupIDs) > 0 {
 		_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
 			ApplicationID: app.ID,
@@ -218,8 +258,29 @@ func (t *TunnelClient) createAccessApp(ctx context.Context, rc *cloudflare.Resou
 	return nil
 }
 
-// updateAccessAppPolicies updates the allow and deny policies on an existing Access Application.
-func (t *TunnelClient) updateAccessAppPolicies(ctx context.Context, rc *cloudflare.ResourceContainer, app cloudflare.AccessApplication, want desiredAccessApp) error {
+// updateAccessApp updates an existing Access Application's settings and policies.
+func (t *TunnelClient) updateAccessApp(ctx context.Context, rc *cloudflare.ResourceContainer, app cloudflare.AccessApplication, want desiredAccessApp) error {
+	// Update app-level settings (session duration, auto-redirect)
+	sessionDuration := defaultSessionDuration
+	if want.SessionDuration != "" {
+		sessionDuration = want.SessionDuration
+	}
+	updateParams := cloudflare.UpdateAccessApplicationParams{
+		ID:              app.ID,
+		Name:            app.Name,
+		Domain:          app.Domain,
+		Type:            cloudflare.SelfHosted,
+		SessionDuration: sessionDuration,
+	}
+	if want.AutoRedirect != nil {
+		updateParams.AutoRedirectToIdentity = want.AutoRedirect
+	}
+	_, err := t.cfClient.UpdateAccessApplication(ctx, rc, updateParams)
+	if err != nil {
+		return errors.Wrap(err, "update access application settings")
+	}
+
+	// Update policies
 	policies, _, err := t.cfClient.ListAccessPolicies(ctx, rc, cloudflare.ListAccessPoliciesParams{
 		ApplicationID: app.ID,
 	})
@@ -227,15 +288,44 @@ func (t *TunnelClient) updateAccessAppPolicies(ctx context.Context, rc *cloudfla
 		return errors.Wrap(err, "list access policies")
 	}
 
-	var allowPolicy *cloudflare.AccessPolicy
-	var denyPolicy *cloudflare.AccessPolicy
+	var allowPolicy, denyPolicy, bypassPolicy *cloudflare.AccessPolicy
 	for i := range policies {
 		switch policies[i].Decision {
 		case "allow":
 			allowPolicy = &policies[i]
 		case "deny":
 			denyPolicy = &policies[i]
+		case "bypass":
+			bypassPolicy = &policies[i]
 		}
+	}
+
+	if want.Bypass {
+		// Ensure bypass policy exists, remove allow/deny if present
+		if bypassPolicy == nil {
+			_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
+				ApplicationID: app.ID,
+				Name:          "bypass",
+				Decision:      "bypass",
+				Precedence:    1,
+				Include:       []interface{}{cloudflare.AccessGroupEveryone{}},
+			})
+			if err != nil {
+				return errors.Wrap(err, "create bypass policy")
+			}
+		}
+		if allowPolicy != nil {
+			_ = t.cfClient.DeleteAccessPolicy(ctx, rc, cloudflare.DeleteAccessPolicyParams{ApplicationID: app.ID, PolicyID: allowPolicy.ID})
+		}
+		if denyPolicy != nil {
+			_ = t.cfClient.DeleteAccessPolicy(ctx, rc, cloudflare.DeleteAccessPolicyParams{ApplicationID: app.ID, PolicyID: denyPolicy.ID})
+		}
+		return nil
+	}
+
+	// Remove bypass policy if switching away from bypass
+	if bypassPolicy != nil {
+		_ = t.cfClient.DeleteAccessPolicy(ctx, rc, cloudflare.DeleteAccessPolicyParams{ApplicationID: app.ID, PolicyID: bypassPolicy.ID})
 	}
 
 	// Update or create allow policy
@@ -291,7 +381,6 @@ func (t *TunnelClient) updateAccessAppPolicies(ctx context.Context, rc *cloudfla
 			}
 		}
 	} else if denyPolicy != nil {
-		// No deny groups desired but a deny policy exists — remove it
 		err = t.cfClient.DeleteAccessPolicy(ctx, rc, cloudflare.DeleteAccessPolicyParams{
 			ApplicationID: app.ID,
 			PolicyID:      denyPolicy.ID,

--- a/pkg/cloudflare-controller/access.go
+++ b/pkg/cloudflare-controller/access.go
@@ -1,0 +1,305 @@
+package cloudflarecontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/pkg/errors"
+)
+
+const accessAppNamePrefix = "ctic"
+
+// accessAppName returns the deterministic name for an owned Access Application.
+// Format: ctic:<tunnelName>:<hostname>
+func accessAppName(tunnelName, hostname string) string {
+	return fmt.Sprintf("%s:%s:%s", accessAppNamePrefix, tunnelName, hostname)
+}
+
+// isOwnedAccessApp returns true if the Access Application was created by this controller instance.
+func isOwnedAccessApp(app cloudflare.AccessApplication, tunnelName string) bool {
+	prefix := fmt.Sprintf("%s:%s:", accessAppNamePrefix, tunnelName)
+	return strings.HasPrefix(app.Name, prefix)
+}
+
+// hostnameFromAccessAppName extracts the hostname from an owned Access Application name.
+func hostnameFromAccessAppName(name, tunnelName string) string {
+	prefix := fmt.Sprintf("%s:%s:", accessAppNamePrefix, tunnelName)
+	return strings.TrimPrefix(name, prefix)
+}
+
+// desiredAccessApp holds the desired state for an Access Application on a given hostname.
+// Group fields contain names from annotations; IDs are resolved at reconcile time.
+type desiredAccessApp struct {
+	AllowedGroupIDs []string
+	DeniedGroupIDs  []string
+}
+
+// resolveGroupNames maps group names to IDs using the provided lookup map.
+// Unknown names are logged and skipped.
+func resolveGroupNames(names []string, nameToID map[string]string) []string {
+	var ids []string
+	for _, name := range names {
+		if id, ok := nameToID[name]; ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// desiredAccessApps computes the desired Access Applications from exposures.
+// For each hostname, it unions all AllowedAccessGroupIDs and DeniedAccessGroupIDs
+// from non-deleted exposures. Hostnames with no allowed groups are omitted.
+func desiredAccessApps(exposures []exposure.Exposure) map[string]desiredAccessApp {
+	result := make(map[string]desiredAccessApp)
+
+	for _, e := range exposures {
+		if e.IsDeleted {
+			continue
+		}
+		if len(e.AllowedAccessGroupIDs) == 0 && len(e.DeniedAccessGroupIDs) == 0 {
+			continue
+		}
+
+		existing := result[e.Hostname]
+		existing.AllowedGroupIDs = unionStrings(existing.AllowedGroupIDs, e.AllowedAccessGroupIDs)
+		existing.DeniedGroupIDs = unionStrings(existing.DeniedGroupIDs, e.DeniedAccessGroupIDs)
+		result[e.Hostname] = existing
+	}
+
+	// Remove entries with no allowed groups — deny-only doesn't make sense without an allow
+	for hostname, app := range result {
+		if len(app.AllowedGroupIDs) == 0 {
+			delete(result, hostname)
+		}
+	}
+
+	return result
+}
+
+// unionStrings returns the union of two string slices, preserving order and deduplicating.
+func unionStrings(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	result := append([]string(nil), a...)
+	for _, s := range b {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// accessGroupIncludeRules builds the include rules for an Access Policy from group IDs.
+func accessGroupIncludeRules(groupIDs []string) []interface{} {
+	rules := make([]interface{}, len(groupIDs))
+	for i, id := range groupIDs {
+		rules[i] = cloudflare.AccessGroupAccessGroup{
+			Group: struct {
+				ID string `json:"id"`
+			}{ID: id},
+		}
+	}
+	return rules
+}
+
+// updateAccessApplications is the main reconcile loop for Access Applications.
+func (t *TunnelClient) updateAccessApplications(ctx context.Context, exposures []exposure.Exposure) error {
+	rc := cloudflare.AccountIdentifier(t.accountId)
+
+	// 0. Resolve group names to IDs — annotations contain names, API needs IDs
+	allGroups, _, err := t.cfClient.ListAccessGroups(ctx, rc, cloudflare.ListAccessGroupsParams{})
+	if err != nil {
+		return errors.Wrap(err, "list access groups")
+	}
+	groupNameToID := make(map[string]string, len(allGroups))
+	for _, g := range allGroups {
+		groupNameToID[g.Name] = g.ID
+	}
+
+	// Resolve names in exposures to IDs
+	for i := range exposures {
+		exposures[i].AllowedAccessGroupIDs = resolveGroupNames(exposures[i].AllowedAccessGroupIDs, groupNameToID)
+		exposures[i].DeniedAccessGroupIDs = resolveGroupNames(exposures[i].DeniedAccessGroupIDs, groupNameToID)
+	}
+
+	// 1. List all Access Applications, filter to owned ones
+	allApps, _, err := t.cfClient.ListAccessApplications(ctx, rc, cloudflare.ListAccessApplicationsParams{})
+	if err != nil {
+		return errors.Wrap(err, "list access applications")
+	}
+
+	ownedApps := make(map[string]cloudflare.AccessApplication) // hostname -> app
+	for _, app := range allApps {
+		if isOwnedAccessApp(app, t.tunnelName) {
+			hostname := hostnameFromAccessAppName(app.Name, t.tunnelName)
+			ownedApps[hostname] = app
+		}
+	}
+
+	// 2. Compute desired state
+	desired := desiredAccessApps(exposures)
+
+	// 3. Create or update to match desired state
+	for hostname, want := range desired {
+		existingApp, exists := ownedApps[hostname]
+		if !exists {
+			t.logger.Info("create access application", "hostname", hostname)
+			err := t.createAccessApp(ctx, rc, hostname, want)
+			if err != nil {
+				return errors.Wrapf(err, "create access application for %s", hostname)
+			}
+		} else {
+			t.logger.V(3).Info("update access application policies", "hostname", hostname, "app-id", existingApp.ID)
+			err := t.updateAccessAppPolicies(ctx, rc, existingApp, want)
+			if err != nil {
+				return errors.Wrapf(err, "update access application policies for %s", hostname)
+			}
+		}
+	}
+
+	// 4. Delete owned apps that are no longer desired
+	for hostname, app := range ownedApps {
+		if _, wanted := desired[hostname]; !wanted {
+			t.logger.Info("delete access application", "hostname", hostname, "app-id", app.ID)
+			err := t.cfClient.DeleteAccessApplication(ctx, rc, app.ID)
+			if err != nil {
+				return errors.Wrapf(err, "delete access application for %s", hostname)
+			}
+		}
+	}
+
+	return nil
+}
+
+// createAccessApp creates an Access Application and its allow (and optionally deny) policies.
+func (t *TunnelClient) createAccessApp(ctx context.Context, rc *cloudflare.ResourceContainer, hostname string, want desiredAccessApp) error {
+	app, err := t.cfClient.CreateAccessApplication(ctx, rc, cloudflare.CreateAccessApplicationParams{
+		Name:            accessAppName(t.tunnelName, hostname),
+		Domain:          hostname,
+		Type:            cloudflare.SelfHosted,
+		SessionDuration: "24h",
+	})
+	if err != nil {
+		return errors.Wrap(err, "create access application")
+	}
+
+	// Create allow policy (precedence 1 = evaluated first by default, but deny at precedence 1 takes priority)
+	_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
+		ApplicationID: app.ID,
+		Name:          "allow",
+		Decision:      "allow",
+		Precedence:    2,
+		Include:       accessGroupIncludeRules(want.AllowedGroupIDs),
+	})
+	if err != nil {
+		return errors.Wrap(err, "create allow policy")
+	}
+
+	// Create deny policy if deny groups are specified (higher precedence = evaluated first)
+	if len(want.DeniedGroupIDs) > 0 {
+		_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
+			ApplicationID: app.ID,
+			Name:          "deny",
+			Decision:      "deny",
+			Precedence:    1,
+			Include:       accessGroupIncludeRules(want.DeniedGroupIDs),
+		})
+		if err != nil {
+			return errors.Wrap(err, "create deny policy")
+		}
+	}
+
+	return nil
+}
+
+// updateAccessAppPolicies updates the allow and deny policies on an existing Access Application.
+func (t *TunnelClient) updateAccessAppPolicies(ctx context.Context, rc *cloudflare.ResourceContainer, app cloudflare.AccessApplication, want desiredAccessApp) error {
+	policies, _, err := t.cfClient.ListAccessPolicies(ctx, rc, cloudflare.ListAccessPoliciesParams{
+		ApplicationID: app.ID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "list access policies")
+	}
+
+	var allowPolicy *cloudflare.AccessPolicy
+	var denyPolicy *cloudflare.AccessPolicy
+	for i := range policies {
+		switch policies[i].Decision {
+		case "allow":
+			allowPolicy = &policies[i]
+		case "deny":
+			denyPolicy = &policies[i]
+		}
+	}
+
+	// Update or create allow policy
+	if allowPolicy != nil {
+		_, err = t.cfClient.UpdateAccessPolicy(ctx, rc, cloudflare.UpdateAccessPolicyParams{
+			ApplicationID: app.ID,
+			PolicyID:      allowPolicy.ID,
+			Name:          "allow",
+			Decision:      "allow",
+			Precedence:    2,
+			Include:       accessGroupIncludeRules(want.AllowedGroupIDs),
+		})
+		if err != nil {
+			return errors.Wrap(err, "update allow policy")
+		}
+	} else {
+		_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
+			ApplicationID: app.ID,
+			Name:          "allow",
+			Decision:      "allow",
+			Precedence:    2,
+			Include:       accessGroupIncludeRules(want.AllowedGroupIDs),
+		})
+		if err != nil {
+			return errors.Wrap(err, "create allow policy")
+		}
+	}
+
+	// Update, create, or delete deny policy
+	if len(want.DeniedGroupIDs) > 0 {
+		if denyPolicy != nil {
+			_, err = t.cfClient.UpdateAccessPolicy(ctx, rc, cloudflare.UpdateAccessPolicyParams{
+				ApplicationID: app.ID,
+				PolicyID:      denyPolicy.ID,
+				Name:          "deny",
+				Decision:      "deny",
+				Precedence:    1,
+				Include:       accessGroupIncludeRules(want.DeniedGroupIDs),
+			})
+			if err != nil {
+				return errors.Wrap(err, "update deny policy")
+			}
+		} else {
+			_, err = t.cfClient.CreateAccessPolicy(ctx, rc, cloudflare.CreateAccessPolicyParams{
+				ApplicationID: app.ID,
+				Name:          "deny",
+				Decision:      "deny",
+				Precedence:    1,
+				Include:       accessGroupIncludeRules(want.DeniedGroupIDs),
+			})
+			if err != nil {
+				return errors.Wrap(err, "create deny policy")
+			}
+		}
+	} else if denyPolicy != nil {
+		// No deny groups desired but a deny policy exists — remove it
+		err = t.cfClient.DeleteAccessPolicy(ctx, rc, cloudflare.DeleteAccessPolicyParams{
+			ApplicationID: app.ID,
+			PolicyID:      denyPolicy.ID,
+		})
+		if err != nil {
+			return errors.Wrap(err, "delete deny policy")
+		}
+	}
+
+	return nil
+}

--- a/pkg/cloudflare-controller/access_test.go
+++ b/pkg/cloudflare-controller/access_test.go
@@ -1,0 +1,317 @@
+package cloudflarecontroller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
+	"github.com/cloudflare/cloudflare-go"
+)
+
+func Test_accessAppName(t *testing.T) {
+	tests := []struct {
+		name       string
+		tunnelName string
+		hostname   string
+		want       string
+	}{
+		{
+			name:       "basic",
+			tunnelName: "k8s-tunnel",
+			hostname:   "grafana.twiechert.de",
+			want:       "ctic:k8s-tunnel:grafana.twiechert.de",
+		},
+		{
+			name:       "subdomain",
+			tunnelName: "my-tunnel",
+			hostname:   "app.sub.example.com",
+			want:       "ctic:my-tunnel:app.sub.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := accessAppName(tt.tunnelName, tt.hostname)
+			if got != tt.want {
+				t.Errorf("accessAppName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isOwnedAccessApp(t *testing.T) {
+	tests := []struct {
+		name       string
+		app        cloudflare.AccessApplication
+		tunnelName string
+		want       bool
+	}{
+		{
+			name:       "owned app",
+			app:        cloudflare.AccessApplication{Name: "ctic:k8s-tunnel:grafana.example.com"},
+			tunnelName: "k8s-tunnel",
+			want:       true,
+		},
+		{
+			name:       "different tunnel",
+			app:        cloudflare.AccessApplication{Name: "ctic:other-tunnel:grafana.example.com"},
+			tunnelName: "k8s-tunnel",
+			want:       false,
+		},
+		{
+			name:       "not owned",
+			app:        cloudflare.AccessApplication{Name: "my-manual-app"},
+			tunnelName: "k8s-tunnel",
+			want:       false,
+		},
+		{
+			name:       "prefix collision",
+			app:        cloudflare.AccessApplication{Name: "ctic:k8s-tunnel-extended:grafana.example.com"},
+			tunnelName: "k8s-tunnel",
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOwnedAccessApp(tt.app, tt.tunnelName)
+			if got != tt.want {
+				t.Errorf("isOwnedAccessApp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_hostnameFromAccessAppName(t *testing.T) {
+	got := hostnameFromAccessAppName("ctic:k8s-tunnel:grafana.example.com", "k8s-tunnel")
+	want := "grafana.example.com"
+	if got != want {
+		t.Errorf("hostnameFromAccessAppName() = %v, want %v", got, want)
+	}
+}
+
+func Test_desiredAccessApps(t *testing.T) {
+	tests := []struct {
+		name      string
+		exposures []exposure.Exposure
+		want      map[string]desiredAccessApp
+	}{
+		{
+			name:      "empty exposures",
+			exposures: nil,
+			want:      map[string]desiredAccessApp{},
+		},
+		{
+			name: "no access groups",
+			exposures: []exposure.Exposure{
+				{Hostname: "app.example.com", ServiceTarget: "http://svc:80"},
+			},
+			want: map[string]desiredAccessApp{},
+		},
+		{
+			name: "single exposure with allowed groups",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:              "app.example.com",
+					AllowedAccessGroupIDs: []string{"group-1", "group-2"},
+				},
+			},
+			want: map[string]desiredAccessApp{
+				"app.example.com": {
+					AllowedGroupIDs: []string{"group-1", "group-2"},
+					DeniedGroupIDs:  nil,
+				},
+			},
+		},
+		{
+			name: "single exposure with both allowed and denied groups",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:              "app.example.com",
+					AllowedAccessGroupIDs: []string{"group-1"},
+					DeniedAccessGroupIDs:  []string{"group-deny"},
+				},
+			},
+			want: map[string]desiredAccessApp{
+				"app.example.com": {
+					AllowedGroupIDs: []string{"group-1"},
+					DeniedGroupIDs:  []string{"group-deny"},
+				},
+			},
+		},
+		{
+			name: "deduplicate same hostname",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:              "app.example.com",
+					PathPrefix:            "/",
+					AllowedAccessGroupIDs: []string{"group-1", "group-2"},
+				},
+				{
+					Hostname:              "app.example.com",
+					PathPrefix:            "/api",
+					AllowedAccessGroupIDs: []string{"group-2", "group-3"},
+				},
+			},
+			want: map[string]desiredAccessApp{
+				"app.example.com": {
+					AllowedGroupIDs: []string{"group-1", "group-2", "group-3"},
+					DeniedGroupIDs:  nil,
+				},
+			},
+		},
+		{
+			name: "skip deleted exposures",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:              "app.example.com",
+					IsDeleted:             true,
+					AllowedAccessGroupIDs: []string{"group-1"},
+				},
+			},
+			want: map[string]desiredAccessApp{},
+		},
+		{
+			name: "deny-only is omitted (no allowed groups)",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:             "app.example.com",
+					DeniedAccessGroupIDs: []string{"group-deny"},
+				},
+			},
+			want: map[string]desiredAccessApp{},
+		},
+		{
+			name: "multiple hostnames",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:              "app1.example.com",
+					AllowedAccessGroupIDs: []string{"group-a"},
+				},
+				{
+					Hostname:              "app2.example.com",
+					AllowedAccessGroupIDs: []string{"group-b"},
+					DeniedAccessGroupIDs:  []string{"group-c"},
+				},
+			},
+			want: map[string]desiredAccessApp{
+				"app1.example.com": {
+					AllowedGroupIDs: []string{"group-a"},
+					DeniedGroupIDs:  nil,
+				},
+				"app2.example.com": {
+					AllowedGroupIDs: []string{"group-b"},
+					DeniedGroupIDs:  []string{"group-c"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := desiredAccessApps(tt.exposures)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("desiredAccessApps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_accessGroupIncludeRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		groupIDs []string
+		want     []interface{}
+	}{
+		{
+			name:     "single group",
+			groupIDs: []string{"abc123"},
+			want: []interface{}{
+				cloudflare.AccessGroupAccessGroup{
+					Group: struct {
+						ID string `json:"id"`
+					}{ID: "abc123"},
+				},
+			},
+		},
+		{
+			name:     "multiple groups",
+			groupIDs: []string{"group-1", "group-2"},
+			want: []interface{}{
+				cloudflare.AccessGroupAccessGroup{
+					Group: struct {
+						ID string `json:"id"`
+					}{ID: "group-1"},
+				},
+				cloudflare.AccessGroupAccessGroup{
+					Group: struct {
+						ID string `json:"id"`
+					}{ID: "group-2"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := accessGroupIncludeRules(tt.groupIDs)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("accessGroupIncludeRules() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolveGroupNames(t *testing.T) {
+	lookup := map[string]string{"admin": "id-1", "viewer": "id-2"}
+
+	got := resolveGroupNames([]string{"admin", "viewer", "unknown"}, lookup)
+	want := []string{"id-1", "id-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolveGroupNames() = %v, want %v", got, want)
+	}
+}
+
+func Test_unionStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{
+			name: "both empty",
+			a:    nil,
+			b:    nil,
+			want: nil,
+		},
+		{
+			name: "a empty",
+			a:    nil,
+			b:    []string{"x"},
+			want: []string{"x"},
+		},
+		{
+			name: "no overlap",
+			a:    []string{"a", "b"},
+			b:    []string{"c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "with overlap",
+			a:    []string{"a", "b"},
+			b:    []string{"b", "c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "fully overlapping",
+			a:    []string{"a", "b"},
+			b:    []string{"a", "b"},
+			want: []string{"a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unionStrings(tt.a, tt.b)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unionStrings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudflare-controller/access_test.go
+++ b/pkg/cloudflare-controller/access_test.go
@@ -180,6 +180,38 @@ func Test_desiredAccessApps(t *testing.T) {
 			want: map[string]desiredAccessApp{},
 		},
 		{
+			name: "bypass creates app without groups",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:     "public.example.com",
+					AccessBypass: true,
+				},
+			},
+			want: map[string]desiredAccessApp{
+				"public.example.com": {
+					Bypass: true,
+				},
+			},
+		},
+		{
+			name: "session duration and auto-redirect propagated",
+			exposures: []exposure.Exposure{
+				{
+					Hostname:              "app.example.com",
+					AllowedAccessGroupIDs: []string{"group-1"},
+					AccessSessionDuration: "1h",
+					AccessAutoRedirect:    boolPtr(true),
+				},
+			},
+			want: map[string]desiredAccessApp{
+				"app.example.com": {
+					AllowedGroupIDs: []string{"group-1"},
+					SessionDuration: "1h",
+					AutoRedirect:    boolPtr(true),
+				},
+			},
+		},
+		{
 			name: "multiple hostnames",
 			exposures: []exposure.Exposure{
 				{
@@ -267,6 +299,8 @@ func Test_resolveGroupNames(t *testing.T) {
 		t.Errorf("resolveGroupNames() = %v, want %v", got, want)
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 func Test_unionStrings(t *testing.T) {
 	tests := []struct {

--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -41,6 +41,11 @@ func (t *TunnelClient) PutExposures(ctx context.Context, exposures []exposure.Ex
 	if err != nil {
 		return errors.Wrap(err, "update DNS CNAME record")
 	}
+
+	err = t.updateAccessApplications(ctx, exposures)
+	if err != nil {
+		return errors.Wrap(err, "update access applications")
+	}
 	return nil
 }
 

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -58,6 +58,21 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			deniedAccessGroupIDs = parseCommaSeparated(raw)
 		}
 
+		var accessBypass bool
+		if raw, ok := getAnnotation(ingress.Annotations, AnnotationAccessBypass); ok {
+			accessBypass = raw == "true"
+		}
+
+		var accessSessionDuration string
+		if raw, ok := getAnnotation(ingress.Annotations, AnnotationAccessSessionDuration); ok {
+			accessSessionDuration = raw
+		}
+
+		var accessAutoRedirect *bool
+		if raw, ok := getAnnotation(ingress.Annotations, AnnotationAccessAutoRedirect); ok {
+			accessAutoRedirect = boolPointer(raw == "true")
+		}
+
 		var proxySSLVerifyEnabled *bool
 
 		if proxySSLVerify, ok := getAnnotation(ingress.Annotations, AnnotationProxySSLVerify); ok {
@@ -126,6 +141,9 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				OriginServerName:      originServerName,
 				AllowedAccessGroupIDs: allowedAccessGroupIDs,
 				DeniedAccessGroupIDs:  deniedAccessGroupIDs,
+				AccessBypass:          accessBypass,
+				AccessSessionDuration: accessSessionDuration,
+				AccessAutoRedirect:    accessAutoRedirect,
 			})
 		}
 	}

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -45,6 +46,16 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 
 		if name, ok := getAnnotation(ingress.Annotations, AnnotationOriginServerName); ok {
 			originServerName = ptr.To(name)
+		}
+
+		var allowedAccessGroupIDs []string
+		if raw, ok := getAnnotation(ingress.Annotations, AnnotationAllowedAccessGroup); ok {
+			allowedAccessGroupIDs = parseCommaSeparated(raw)
+		}
+
+		var deniedAccessGroupIDs []string
+		if raw, ok := getAnnotation(ingress.Annotations, AnnotationDeniedAccessGroup); ok {
+			deniedAccessGroupIDs = parseCommaSeparated(raw)
 		}
 
 		var proxySSLVerifyEnabled *bool
@@ -113,6 +124,8 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				ProxySSLVerifyEnabled: proxySSLVerifyEnabled,
 				HTTPHostHeader:        httpHostHeader,
 				OriginServerName:      originServerName,
+				AllowedAccessGroupIDs: allowedAccessGroupIDs,
+				DeniedAccessGroupIDs:  deniedAccessGroupIDs,
 			})
 		}
 	}
@@ -152,4 +165,15 @@ func getAnnotation(annotations map[string]string, key string) (string, bool) {
 
 func boolPointer(b bool) *bool {
 	return &b
+}
+
+func parseCommaSeparated(raw string) []string {
+	var result []string
+	for _, s := range strings.Split(raw, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			result = append(result, s)
+		}
+	}
+	return result
 }

--- a/pkg/controller/weel_known_annotations.go
+++ b/pkg/controller/weel_known_annotations.go
@@ -19,3 +19,12 @@ const AnnotationAllowedAccessGroup = "cloudflare-tunnel-ingress-controller.strrl
 
 // AnnotationDeniedAccessGroup is a comma-separated list of Cloudflare Access Group IDs to deny.
 const AnnotationDeniedAccessGroup = "cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-denied-group"
+
+// AnnotationAccessBypass when set to "true", creates a bypass Access Application for the hostname.
+const AnnotationAccessBypass = "cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-bypass"
+
+// AnnotationAccessSessionDuration sets the session duration for the Access Application (e.g. "1h", "24h").
+const AnnotationAccessSessionDuration = "cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-session-duration"
+
+// AnnotationAccessAutoRedirect when "true", skips the IdP selection page and redirects directly to the provider.
+const AnnotationAccessAutoRedirect = "cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-auto-redirect"

--- a/pkg/controller/weel_known_annotations.go
+++ b/pkg/controller/weel_known_annotations.go
@@ -13,3 +13,9 @@ const AnnotationHTTPHostHeader = "cloudflare-tunnel-ingress-controller.strrl.dev
 
 // AnnotationOriginServerName is the hostname on the origin server certificate.
 const AnnotationOriginServerName = "cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name"
+
+// AnnotationAllowedAccessGroup is a comma-separated list of Cloudflare Access Group IDs to allow.
+const AnnotationAllowedAccessGroup = "cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-allowed-group"
+
+// AnnotationDeniedAccessGroup is a comma-separated list of Cloudflare Access Group IDs to deny.
+const AnnotationDeniedAccessGroup = "cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-denied-group"

--- a/pkg/exposure/exposure.go
+++ b/pkg/exposure/exposure.go
@@ -16,4 +16,10 @@ type Exposure struct {
 	HTTPHostHeader *string
 	// OriginServerName is the hostname on the origin server certificate.
 	OriginServerName *string
+	// AllowedAccessGroupIDs is the list of Cloudflare Access Group IDs to allow.
+	// When non-empty, a Cloudflare Access Application is created for the hostname.
+	AllowedAccessGroupIDs []string
+	// DeniedAccessGroupIDs is the list of Cloudflare Access Group IDs to deny.
+	// Creates a higher-precedence deny policy on the Access Application.
+	DeniedAccessGroupIDs []string
 }

--- a/pkg/exposure/exposure.go
+++ b/pkg/exposure/exposure.go
@@ -22,4 +22,10 @@ type Exposure struct {
 	// DeniedAccessGroupIDs is the list of Cloudflare Access Group IDs to deny.
 	// Creates a higher-precedence deny policy on the Access Application.
 	DeniedAccessGroupIDs []string
+	// AccessBypass when true creates a bypass Access Application (no auth required).
+	AccessBypass bool
+	// AccessSessionDuration overrides the default session duration (e.g. "1h", "24h").
+	AccessSessionDuration string
+	// AccessAutoRedirect when non-nil, controls whether to skip the IdP selection page.
+	AccessAutoRedirect *bool
 }


### PR DESCRIPTION
Builds on #277. Three new annotations for Access Application settings:

```
cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-bypass: "true"
cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-session-duration: "1h"
cloudflare-tunnel-ingress-controller.strrl.dev/cloudflare-access-auto-redirect: "true"
```

- **bypass**: I use this for exposing my IdP via the tunnel.
- **session-duration**: overrides the default 24h session. Shorter durations for sensitive services.
- **auto-redirect**: skips the IdP selection page and redirects straight to the provider. 