### PR TITLE
🧹 Use `ptr.To` Instead of `boolPointer`

### DIFF
--- a/pkg/cloudflare-controller/bootstrap.go
+++ b/pkg/cloudflare-controller/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 )
 
 func BootstrapTunnelClientWithTunnelName(ctx context.Context, logger logr.Logger, cfClient *cloudflare.API, accountId string, tunnelName string) (*TunnelClient, error) {
@@ -23,7 +24,7 @@ func BootstrapTunnelClientWithTunnelName(ctx context.Context, logger logr.Logger
 func GetTunnelIdFromTunnelName(ctx context.Context, logger logr.Logger, cfClient *cloudflare.API, tunnelName string, accountId string) (string, error) {
 	logger.V(3).Info("list cloudflare tunnels", "account-id", accountId)
 	tunnels, _, err := cfClient.ListTunnels(ctx, cloudflare.ResourceIdentifier(accountId), cloudflare.TunnelListParams{
-		IsDeleted: boolPointer(false),
+		IsDeleted: ptr.To(false),
 		// FIXME: that's a workaround for https://github.com/cloudflare/cloudflare-go/issues/1247
 		ResultInfo: cloudflare.ResultInfo{
 			Page:    1,
@@ -60,8 +61,4 @@ func GetTunnelIdFromTunnelName(ctx context.Context, logger logr.Logger, cfClient
 	}
 
 	return newTunnel.ID, nil
-}
-
-func boolPointer(b bool) *bool {
-	return &b
 }

--- a/pkg/cloudflare-controller/transform.go
+++ b/pkg/cloudflare-controller/transform.go
@@ -7,6 +7,7 @@ import (
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 )
 
 func fromExposureToCloudflareIngress(ctx context.Context, exposure exposure.Exposure) (*cloudflare.UnvalidatedIngressRule, error) {
@@ -33,9 +34,9 @@ func fromExposureToCloudflareIngress(ctx context.Context, exposure exposure.Expo
 		}
 		result.OriginRequest.OriginServerName = exposure.OriginServerName
 		if exposure.ProxySSLVerifyEnabled == nil {
-			result.OriginRequest.NoTLSVerify = boolPointer(true)
+			result.OriginRequest.NoTLSVerify = ptr.To(true)
 		} else {
-			result.OriginRequest.NoTLSVerify = boolPointer(!*exposure.ProxySSLVerifyEnabled)
+			result.OriginRequest.NoTLSVerify = ptr.To(!*exposure.ProxySSLVerifyEnabled)
 		}
 	}
 

--- a/pkg/cloudflare-controller/transform_test.go
+++ b/pkg/cloudflare-controller/transform_test.go
@@ -109,7 +109,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Path:     "/",
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
-					NoTLSVerify:      boolPointer(true),
+					NoTLSVerify:      ptr.To(true),
 					OriginServerName: ptr.To("bar.internal"),
 				},
 			},
@@ -132,7 +132,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Path:     "/",
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
-					NoTLSVerify:      boolPointer(true),
+					NoTLSVerify:      ptr.To(true),
 					HTTPHostHeader:   ptr.To("foo.internal"),
 					OriginServerName: ptr.To("bar.internal"),
 				},
@@ -153,7 +153,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Path:     "/",
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
-					NoTLSVerify: boolPointer(true),
+					NoTLSVerify: ptr.To(true),
 				},
 			},
 		}, {
@@ -165,7 +165,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 					ServiceTarget:         "https://10.0.0.1:443",
 					PathPrefix:            "/",
 					IsDeleted:             false,
-					ProxySSLVerifyEnabled: boolPointer(false),
+					ProxySSLVerifyEnabled: ptr.To(false),
 				},
 			},
 			want: &cloudflare.UnvalidatedIngressRule{
@@ -173,7 +173,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Path:     "/",
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
-					NoTLSVerify: boolPointer(true),
+					NoTLSVerify: ptr.To(true),
 				},
 			},
 		}, {
@@ -185,7 +185,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 					ServiceTarget:         "https://10.0.0.1:443",
 					PathPrefix:            "/",
 					IsDeleted:             false,
-					ProxySSLVerifyEnabled: boolPointer(true),
+					ProxySSLVerifyEnabled: ptr.To(true),
 				},
 			},
 			want: &cloudflare.UnvalidatedIngressRule{
@@ -193,7 +193,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Path:     "/",
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
-					NoTLSVerify: boolPointer(false),
+					NoTLSVerify: ptr.To(false),
 				},
 			},
 		},

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -52,9 +52,9 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 		if proxySSLVerify, ok := getAnnotation(ingress.Annotations, AnnotationProxySSLVerify); ok {
 			switch proxySSLVerify {
 			case AnnotationProxySSLVerifyOn:
-				proxySSLVerifyEnabled = boolPointer(true)
+				proxySSLVerifyEnabled = ptr.To(true)
 			case AnnotationProxySSLVerifyOff:
-				proxySSLVerifyEnabled = boolPointer(false)
+				proxySSLVerifyEnabled = ptr.To(false)
 			default:
 				return nil, errors.Errorf(
 					"invalid value for annotation %s, available values: \"%s\" or \"%s\"",
@@ -148,8 +148,4 @@ func getPortWithName(ports []v1.ServicePort, portName string) (bool, int32) {
 func getAnnotation(annotations map[string]string, key string) (string, bool) {
 	value, ok := annotations[key]
 	return value, ok
-}
-
-func boolPointer(b bool) *bool {
-	return &b
 }


### PR DESCRIPTION
**What:** Replaced the custom `boolPointer` helper function with the standard `ptr.To` function from `k8s.io/utils/ptr`.

**Why:** Using standard library functions improves code maintainability, reduces code duplication, and follows Go idioms.

**Verification:** Verified by running the relevant tests (`go test ./pkg/controller/... ./pkg/cloudflare-controller/...`), ensuring that the changes are safe and do not introduce regressions.

**Result:** The code is cleaner and uses a standard utility for pointer creation.

---
*PR created automatically by Jules for task [11717493977487167105](https://jules.google.com/task/11717493977487167105) started by @STRRL*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `*bool` values are constructed, with no behavioral changes expected aside from pointer allocation mechanics.
> 
> **Overview**
> Replaces the local `boolPointer` helper with `k8s.io/utils/ptr.To` for creating `*bool` values across the Cloudflare controller and ingress-to-exposure transform logic.
> 
> Removes the now-unused `boolPointer` functions and updates related tests to assert against `ptr.To(...)` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daf9e0abad87d022b4363f518336db33cc64928b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->