### PR TITLE
⚡ Optimize Ingress service lookup to prevent N+1 API calls

### DIFF
--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -22,6 +22,7 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 		logger.Info("ingress has tls specified, SSL Passthrough is not supported, it will be ignored.")
 	}
 
+	serviceCache := make(map[types.NamespacedName]*v1.Service)
 	var result []exposure.Exposure
 	for _, rule := range ingress.Spec.Rules {
 		if rule.Host == "" {
@@ -70,13 +71,20 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				Namespace: ingress.GetNamespace(),
 				Name:      path.Backend.Service.Name,
 			}
-			service := v1.Service{}
-			err := kubeClient.Get(ctx, namespacedName, &service)
-			if err != nil {
-				return nil, errors.Wrapf(err, "fetch service %s", namespacedName)
+
+			var service *v1.Service
+			if cached, ok := serviceCache[namespacedName]; ok {
+				service = cached
+			} else {
+				service = &v1.Service{}
+				err := kubeClient.Get(ctx, namespacedName, service)
+				if err != nil {
+					return nil, errors.Wrapf(err, "fetch service %s", namespacedName)
+				}
+				serviceCache[namespacedName] = service
 			}
 
-			host, err := getHostFromService(&service, clusterDomain)
+			host, err := getHostFromService(service, clusterDomain)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Optimize Ingress service lookup to prevent N+1 API calls

This change introduces local caching for Kubernetes Service lookups within the `FromIngressToExposure` function. Previously, the controller would fetch the Service definition for every path in an Ingress rule, leading to redundant API calls when multiple paths pointed to the same Service.

By caching the Service objects in a map keyed by NamespacedName, we ensure each Service is fetched only once per reconciliation loop, significantly reducing the load on the Kubernetes API server for complex Ingress resources.

Verified with a benchmark test that confirmed a reduction from N calls to 1 call for N paths sharing a service.

---
*PR created automatically by Jules for task [15428160255442119210](https://jules.google.com/task/15428160255442119210) started by @STRRL*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization; behavior should be unchanged aside from reducing repeated `kubeClient.Get` calls, with minor risk of pointer reuse affecting in-function mutation (none observed).
> 
> **Overview**
> Reduces Kubernetes API calls in `FromIngressToExposure` by adding an in-function cache of `Service` objects keyed by `types.NamespacedName`, so multiple ingress paths pointing to the same service reuse a single `kubeClient.Get` result.
> 
> This refactors service retrieval to use cached `*v1.Service` values and passes the pointer through to `getHostFromService`, without changing exposure generation logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 294a77bb134321aa9ac6ee12d334c16217c51a3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->