### PR TITLE
🔒 Fix sensitive API token logging

### DIFF
--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -60,7 +60,7 @@ func main() {
 			logger := options.logger
 			logger.Info("logging verbosity", "level", options.logLevel)
 
-			logger.V(3).Info("build cloudflare client with API Token", "api-token", options.cloudflareAPIToken)
+			logger.V(3).Info("build cloudflare client with API Token", "api-token", "***")
 			cloudflareClient, err := cloudflare.NewWithAPIToken(options.cloudflareAPIToken)
 			if err != nil {
 				logger.Error(err, "create cloudflare client")

--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -60,7 +60,7 @@ func main() {
 			logger := options.logger
 			logger.Info("logging verbosity", "level", options.logLevel)
 
-			logger.V(3).Info("build cloudflare client with API Token", "api-token", "***")
+			logger.V(3).Info("build cloudflare client with API Token", "api-token", "<redacted>")
 			cloudflareClient, err := cloudflare.NewWithAPIToken(options.cloudflareAPIToken)
 			if err != nil {
 				logger.Error(err, "create cloudflare client")


### PR DESCRIPTION
🎯 **What:** Masked the Cloudflare API token in the application logs.
⚠️ **Risk:** The API token was being logged in cleartext when the log level was set to 3 (debug). This could allow unauthorized access to the Cloudflare account if the logs were exposed.
🛡️ **Solution:** Replaced the actual API token value with `***` in the log message at `cmd/cloudflare-tunnel-ingress-controller/main.go`. This ensures that the token is not written to the logs while still providing debug information that the client build step was reached.


---
*PR created automatically by Jules for task [3087765264449044706](https://jules.google.com/task/3087765264449044706) started by @STRRL*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a debug-level log field to avoid leaking credentials; no functional behavior or API calls are modified.
> 
> **Overview**
> Prevents leaking the Cloudflare API token by masking it in the `V(3)` log message in `cmd/cloudflare-tunnel-ingress-controller/main.go` (logs `"***"` instead of the real token) while still indicating the client initialization step occurred.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b489b513767d824bb3f70769285caf68cb895eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->