### PR TITLE
Sort wildcard domain ingress routes after non-wildcard routes

### DIFF
--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -66,14 +66,10 @@ func (t *TunnelClient) updateTunnelIngressRules(ctx context.Context, exposures [
 		ingressRules = append(ingressRules, *ingress)
 	}
 
-	// sort the rules by hostnames first for prettiness, then by path length in descending order
+	// sort the rules: non-wildcard hostnames before wildcard hostnames (wildcards are fallbacks),
+	// then alphabetically by hostname, then by path length in descending order
 	// to ensure "precedence will be given first to the longest matching path".
-	slices.SortFunc(ingressRules, func(a, b cloudflare.UnvalidatedIngressRule) int {
-		if v := strings.Compare(strings.ToLower(a.Hostname), strings.ToLower(b.Hostname)); v != 0 {
-			return v
-		}
-		return len(b.Path) - len(a.Path)
-	})
+	slices.SortFunc(ingressRules, compareIngressRules)
 
 	// at last, append a default 404 service as default route
 	ingressRules = append(ingressRules, cloudflare.UnvalidatedIngressRule{
@@ -230,4 +226,22 @@ func findZoneByName(zoneName string, zones []cloudflare.Zone) (bool, cloudflare.
 
 func (t *TunnelClient) FetchTunnelToken(ctx context.Context) (string, error) {
 	return t.cfClient.GetTunnelToken(ctx, cloudflare.ResourceIdentifier(t.accountId), t.tunnelId)
+}
+
+// compareIngressRules defines the sort order for Cloudflare tunnel ingress rules:
+// non-wildcard hostnames before wildcard hostnames (wildcards act as fallbacks),
+// then alphabetically by hostname, then by path length in descending order.
+func compareIngressRules(a, b cloudflare.UnvalidatedIngressRule) int {
+	aIsWildcard := strings.HasPrefix(a.Hostname, "*.")
+	bIsWildcard := strings.HasPrefix(b.Hostname, "*.")
+	if aIsWildcard != bIsWildcard {
+		if aIsWildcard {
+			return 1
+		}
+		return -1
+	}
+	if v := strings.Compare(strings.ToLower(a.Hostname), strings.ToLower(b.Hostname)); v != 0 {
+		return v
+	}
+	return len(b.Path) - len(a.Path)
 }

--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -69,7 +69,7 @@ func (t *TunnelClient) updateTunnelIngressRules(ctx context.Context, exposures [
 	// sort the rules: non-wildcard hostnames before wildcard hostnames (wildcards are fallbacks),
 	// then alphabetically by hostname, then by path length in descending order
 	// to ensure "precedence will be given first to the longest matching path".
-	slices.SortFunc(ingressRules, compareIngressRules)
+	slices.SortFunc(ingressRules, sortIngressRules)
 
 	// at last, append a default 404 service as default route
 	ingressRules = append(ingressRules, cloudflare.UnvalidatedIngressRule{
@@ -228,10 +228,10 @@ func (t *TunnelClient) FetchTunnelToken(ctx context.Context) (string, error) {
 	return t.cfClient.GetTunnelToken(ctx, cloudflare.ResourceIdentifier(t.accountId), t.tunnelId)
 }
 
-// compareIngressRules defines the sort order for Cloudflare tunnel ingress rules:
+// sortIngressRules defines the sort order for Cloudflare tunnel ingress rules:
 // non-wildcard hostnames before wildcard hostnames (wildcards act as fallbacks),
 // then alphabetically by hostname, then by path length in descending order.
-func compareIngressRules(a, b cloudflare.UnvalidatedIngressRule) int {
+func sortIngressRules(a, b cloudflare.UnvalidatedIngressRule) int {
 	aIsWildcard := strings.HasPrefix(a.Hostname, "*.")
 	bIsWildcard := strings.HasPrefix(b.Hostname, "*.")
 	if aIsWildcard != bIsWildcard {

--- a/pkg/cloudflare-controller/tunnel-client_test.go
+++ b/pkg/cloudflare-controller/tunnel-client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 )
 
-func Test_compareIngressRules(t *testing.T) {
+func Test_sortIngressRules(t *testing.T) {
 	tests := []struct {
 		name      string
 		input     []cloudflare.UnvalidatedIngressRule
@@ -71,7 +71,7 @@ func Test_compareIngressRules(t *testing.T) {
 			rules := make([]cloudflare.UnvalidatedIngressRule, len(tt.input))
 			copy(rules, tt.input)
 
-			slices.SortFunc(rules, compareIngressRules)
+			slices.SortFunc(rules, sortIngressRules)
 
 			for i, rule := range rules {
 				if rule.Hostname != tt.wantOrder[i] {

--- a/pkg/cloudflare-controller/tunnel-client_test.go
+++ b/pkg/cloudflare-controller/tunnel-client_test.go
@@ -1,0 +1,75 @@
+package cloudflarecontroller
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+)
+
+func Test_compareIngressRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []cloudflare.UnvalidatedIngressRule
+		wantOrder []string // expected hostname order after sort
+	}{
+		{
+			name: "wildcard sorts after explicit hostname",
+			input: []cloudflare.UnvalidatedIngressRule{
+				{Hostname: "*.example.com", Path: "/"},
+				{Hostname: "app.example.com", Path: "/"},
+			},
+			wantOrder: []string{"app.example.com", "*.example.com"},
+		},
+		{
+			name: "multiple explicit hostnames before wildcard",
+			input: []cloudflare.UnvalidatedIngressRule{
+				{Hostname: "*.example.com", Path: "/"},
+				{Hostname: "app.example.com", Path: "/"},
+				{Hostname: "api.example.com", Path: "/"},
+			},
+			wantOrder: []string{"api.example.com", "app.example.com", "*.example.com"},
+		},
+		{
+			name: "non-wildcard only sorts alphabetically",
+			input: []cloudflare.UnvalidatedIngressRule{
+				{Hostname: "z.example.com", Path: "/"},
+				{Hostname: "a.example.com", Path: "/"},
+			},
+			wantOrder: []string{"a.example.com", "z.example.com"},
+		},
+		{
+			name: "path length descending for same hostname",
+			input: []cloudflare.UnvalidatedIngressRule{
+				{Hostname: "app.example.com", Path: "/"},
+				{Hostname: "app.example.com", Path: "/longer/path"},
+			},
+			wantOrder: []string{"app.example.com", "app.example.com"},
+		},
+		{
+			name: "wildcard and explicit with different domains",
+			input: []cloudflare.UnvalidatedIngressRule{
+				{Hostname: "*.b.example.com", Path: "/"},
+				{Hostname: "*.a.example.com", Path: "/"},
+				{Hostname: "app.b.example.com", Path: "/"},
+				{Hostname: "app.a.example.com", Path: "/"},
+			},
+			wantOrder: []string{"app.a.example.com", "app.b.example.com", "*.a.example.com", "*.b.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules := make([]cloudflare.UnvalidatedIngressRule, len(tt.input))
+			copy(rules, tt.input)
+
+			slices.SortFunc(rules, compareIngressRules)
+
+			for i, rule := range rules {
+				if rule.Hostname != tt.wantOrder[i] {
+					t.Errorf("position %d: got hostname %q, want %q", i, rule.Hostname, tt.wantOrder[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/cloudflare-controller/tunnel-client_test.go
+++ b/pkg/cloudflare-controller/tunnel-client_test.go
@@ -47,6 +47,14 @@ func Test_compareIngressRules(t *testing.T) {
 			wantOrder: []string{"app.example.com", "app.example.com"},
 		},
 		{
+			name: "single character subdomain sorts before wildcard",
+			input: []cloudflare.UnvalidatedIngressRule{
+				{Hostname: "*.example.com", Path: "/"},
+				{Hostname: "x.example.com", Path: "/"},
+			},
+			wantOrder: []string{"x.example.com", "*.example.com"},
+		},
+		{
 			name: "wildcard and explicit with different domains",
 			input: []cloudflare.UnvalidatedIngressRule{
 				{Hostname: "*.b.example.com", Path: "/"},


### PR DESCRIPTION
I had a use-case where I wanted an ingress rule using a wildcard domain to act as a fallback when a more explicit rule did not exist, however with the sort logic of shortest hostnames first, the wildcard domain name was always taking priority even when a more specific domain name without a wildcard existed in a separate ingress route.

This change makes wildcard domains (e.g. `*.example.com`) be sorted after, and therefore take lower priority than non-wildcard domains (`test.example.com`), which seems to be a more sensible default behaviour to me.

If you'd like to test this, you can use the following helm values for now:

```yaml
cloudflare-tunnel-ingress-controller:
  image:
    repository: ghcr.io/joelcox22/cloudflare-tunnel-ingress-controller
    tag: master-df3c2fb-amd64
```

Then deploy an ingress route with a wildcard, and you will see it's sorted in cloudflare connector application routes below the non-wildcard routes, where without this change, it ended up at the top of the list due to the hostname being shorter than the other routes that had more explicit domain names.

---

Note: these code changes and tests are generated by AI, but have been reviewed and tested by a human 😄 
