### PR TITLE
feat: add per-ingress annotation to disable DNS record management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Pre-commit hooks are managed via [prek](https://prek.j178.dev/) (configured in `
 - `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol`: Backend protocol (default: "http")
 - `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`: Set HTTP Host header for the local webserver
 - `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`: Hostname on the origin server certificate
+- `cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management`: Disable Cloudflare DNS record (CNAME/TXT) management for the ingress while still configuring the tunnel ingress rule, so DNS can be delegated to an external system such as external-dns or a Cloudflare Load Balancer ("true" or "false", default "false")
 
 ## Testing Strategy
 

--- a/pkg/cloudflare-controller/dns.go
+++ b/pkg/cloudflare-controller/dns.go
@@ -71,6 +71,13 @@ func syncDNSRecord(
 
 	// Create or update CNAME/TXT records for active exposures
 	for _, item := range effectiveExposures {
+		// DNS management is delegated externally for this exposure: skip creating or
+		// updating its records. It stays in effectiveExposures so the deletion pass
+		// below still treats its hostname as known and leaves existing records alone.
+		if item.DisableDNSManagement {
+			continue
+		}
+
 		txtRecordName := fmt.Sprintf("%s.%s", ManagedRecordTXTPrefix, item.Hostname)
 
 		// Handle CNAME record

--- a/pkg/cloudflare-controller/dns_test.go
+++ b/pkg/cloudflare-controller/dns_test.go
@@ -335,6 +335,64 @@ func Test_syncDNSRecord(t *testing.T) {
 			wantDelete: nil,
 			wantErr:    false,
 		},
+		{
+			name: "exposure with DNS management disabled creates no records",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:             "test.example.com",
+						ServiceTarget:        "http://10.0.0.1:233",
+						PathPrefix:           "/",
+						IsDeleted:            false,
+						DisableDNSManagement: true,
+					},
+				},
+				existedCNAMERecords: nil,
+				existedTXTRecords:   nil,
+				tunnelId:            WhateverTunnelId,
+				tunnelName:          "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: nil,
+			wantErr:    false,
+		},
+		{
+			name: "exposure with DNS management disabled does not delete existing record",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:             "test.example.com",
+						ServiceTarget:        "http://10.0.0.1:233",
+						PathPrefix:           "/",
+						IsDeleted:            false,
+						DisableDNSManagement: true,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: nil,
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -183,6 +183,12 @@ func (t *TunnelClient) updateDNSCNAMERecord(ctx context.Context, exposures []exp
 		ok, zone := zoneBelongedByExposure(item, zoneNames)
 		if ok {
 			exposuresByZone[zone] = append(exposuresByZone[zone], item)
+		} else if item.DisableDNSManagement {
+			// DNS management is delegated externally for this exposure; its hostname
+			// may live in a zone not managed by this Cloudflare account, so don't
+			// require a zone match and skip it from DNS reconciliation.
+			t.logger.V(3).Info("DNS management disabled for exposure, skipping DNS reconciliation", "hostname", item.Hostname)
+			continue
 		} else {
 			return errors.Errorf("hostname %s not belong to any zone", item.Hostname)
 		}

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -47,6 +47,24 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			originServerName = ptr.To(name)
 		}
 
+		disableDNSManagement := false
+
+		if value, ok := getAnnotation(ingress.Annotations, AnnotationDisableDNSManagement); ok {
+			switch value {
+			case AnnotationDisableDNSManagementTrue:
+				disableDNSManagement = true
+			case AnnotationDisableDNSManagementFalse:
+				disableDNSManagement = false
+			default:
+				return nil, errors.Errorf(
+					"invalid value for annotation %s, available values: \"%s\" or \"%s\"",
+					AnnotationDisableDNSManagement,
+					AnnotationDisableDNSManagementTrue,
+					AnnotationDisableDNSManagementFalse,
+				)
+			}
+		}
+
 		var proxySSLVerifyEnabled *bool
 
 		if proxySSLVerify, ok := getAnnotation(ingress.Annotations, AnnotationProxySSLVerify); ok {
@@ -113,6 +131,7 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				ProxySSLVerifyEnabled: proxySSLVerifyEnabled,
 				HTTPHostHeader:        httpHostHeader,
 				OriginServerName:      originServerName,
+				DisableDNSManagement:  disableDNSManagement,
 			})
 		}
 	}

--- a/pkg/controller/well_known_annotations.go
+++ b/pkg/controller/well_known_annotations.go
@@ -13,3 +13,11 @@ const AnnotationHTTPHostHeader = "cloudflare-tunnel-ingress-controller.strrl.dev
 
 // AnnotationOriginServerName is the hostname on the origin server certificate.
 const AnnotationOriginServerName = "cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name"
+
+// AnnotationDisableDNSManagement disables Cloudflare DNS record (CNAME/TXT) management
+// for this ingress, while still configuring the tunnel ingress rule. This allows DNS to be
+// delegated to an external system, e.g. external-dns or a Cloudflare Load Balancer that
+// targets the tunnel directly. Available values: "true" or "false", default "false".
+const AnnotationDisableDNSManagement = "cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management"
+const AnnotationDisableDNSManagementTrue = "true"
+const AnnotationDisableDNSManagementFalse = "false"

--- a/pkg/exposure/exposure.go
+++ b/pkg/exposure/exposure.go
@@ -16,4 +16,9 @@ type Exposure struct {
 	HTTPHostHeader *string
 	// OriginServerName is the hostname on the origin server certificate.
 	OriginServerName *string
+	// DisableDNSManagement, when true, makes the controller skip Cloudflare DNS
+	// record (CNAME/TXT) management for this exposure while still configuring the
+	// tunnel ingress rule. DNS can then be delegated to an external system, e.g.
+	// external-dns or a Cloudflare Load Balancer targeting the tunnel directly.
+	DisableDNSManagement bool
 }


### PR DESCRIPTION
## What

Adds a per-ingress annotation to disable DNS record management:

```
cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management: "true"
```

Flagged ingresses still get their tunnel ingress rules reconciled, but the controller skips Cloudflare DNS record (CNAME/TXT) creation and updates for their hostnames, and no longer errors when such a hostname belongs to no managed zone.

## Why

Closes #310.

DNS management was hard-coupled into `PutExposures`: every reconcile wrote a CNAME `host → <tunnel-id>.cfargotunnel.com` plus an ownership TXT. That made it impossible to delegate DNS for individual hosts to external-dns or to put a Cloudflare Load Balancer in front of the tunnel.

## Note

(Maintainer edit: original description covered an earlier global-flag design; rewritten to match the annotation-based implementation that actually shipped. Known follow-up tracked separately: when the annotation is enabled on a previously managed ingress, the controller should clean up its own previously created records and ownership TXT.)