### PR TITLE
Pin unpinned-action references across 8 workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -18,19 +18,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: './go.mod'
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
         with:
           version: 'latest'
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e
         with:
           driver: docker
           container-runtime: docker
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ./test/e2e/artifacts/e2e-cover.out
           flags: e2e
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: e2e-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
           path: test/e2e/artifacts/

--- a/.github/workflows/helm-package-test.yaml
+++ b/.github/workflows/helm-package-test.yaml
@@ -14,8 +14,8 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
       - name: Run helm package
         run: |
           helm package ./helm/cloudflare-tunnel-ingress-controller

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,15 +14,15 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: './go.mod'
       - name: Run integration tests
         run: |
           make integration-test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ./test/integration/cover.out
           flags: integration

--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -16,13 +16,13 @@ jobs:
       owner: ${{ steps.lowercase.outputs.owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Convert owner to lowercase
         id: lowercase
         run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: |
             ghcr.io/${{ steps.lowercase.outputs.owner }}/cloudflare-tunnel-ingress-controller
@@ -40,17 +40,17 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ needs.metadata.outputs.owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push AMD64
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           file: image/cloudflare-tunnel-ingress-controller/Dockerfile
           platforms: linux/amd64
@@ -68,17 +68,17 @@ jobs:
       "arm64",
     ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ needs.metadata.outputs.owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push ARM64
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           file: image/cloudflare-tunnel-ingress-controller/Dockerfile
           platforms: linux/arm64
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ needs.metadata.outputs.owner }}

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -11,7 +11,7 @@ jobs:
   release-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: "Extract Version"
         id: extract_version
         run: |
@@ -19,7 +19,7 @@ jobs:
           VERSION=${GIT_TAG##v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Publish Helm chart
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82
         with:
           token: ${{ secrets.HELM_TOKEN }}
           charts_dir: helm

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,15 +14,15 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: './go.mod'
       - name: Run unit tests
         run: |
           make unit-test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ./cover.out
           flags: unit


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/claude-code-review.yml`

- 🟠 MED `anthropics/claude-code-action` (job `claude-review`)
- ⚪ LOW `actions/checkout` (job `claude-review`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
```

</details>

### `.github/workflows/claude.yml`

- 🟠 MED `anthropics/claude-code-action` (job `claude`)
- ⚪ LOW `actions/checkout` (job `claude`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
```

</details>

### `.github/workflows/e2e-test.yaml`

- 🟠 MED `azure/setup-helm` (job `e2e-test`)
- 🟠 MED `medyagh/setup-minikube` (job `e2e-test`)
- 🟠 MED `codecov/codecov-action` (job `e2e-test`)
- ⚪ LOW `actions/checkout` (job `e2e-test`)
- ⚪ LOW `actions/setup-go` (job `e2e-test`)
- ⚪ LOW `actions/upload-artifact` (job `e2e-test`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -18,19 +18,19 @@
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: './go.mod'
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
         with:
           version: 'latest'
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e
         with:
           driver: docker
           container-runtime: docker
@@ -62,7 +62,7 @@
 
       - name: Upload coverage reports to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ./test/e2e/artifacts/e2e-cover.out
           flags: e2e
@@ -70,7 +70,7 @@
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
... (4 more diff lines — see Files changed)
```

</details>

### `.github/workflows/helm-package-test.yaml`

- 🟠 MED `azure/setup-helm` (job `integration-test`)
- ⚪ LOW `actions/checkout` (job `integration-test`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/helm-package-test.yaml
+++ b/.github/workflows/helm-package-test.yaml
@@ -14,8 +14,8 @@
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
       - name: Run helm package
         run: |
           helm package ./helm/cloudflare-tunnel-ingress-controller
```

</details>

### `.github/workflows/integration-test.yaml`

- 🟠 MED `codecov/codecov-action` (job `integration-test`)
- ⚪ LOW `actions/checkout` (job `integration-test`)
- ⚪ LOW `actions/setup-go` (job `integration-test`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,15 +14,15 @@
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: './go.mod'
       - name: Run integration tests
         run: |
           make integration-test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ./test/integration/cover.out
           flags: integration
```

</details>

### `.github/workflows/release-container-image.yaml`

- 🟠 MED `docker/metadata-action` (job `metadata`)
- 🟠 MED `docker/setup-buildx-action` (job `build-amd64`)
- 🟠 MED `docker/login-action` (job `build-amd64`)
- 🟠 MED `docker/build-push-action` (job `build-amd64`)
- 🟠 MED `docker/setup-buildx-action` (job `build-arm64`)
- 🟠 MED `docker/login-action` (job `build-arm64`)
- 🟠 MED `docker/build-push-action` (job `build-arm64`)
- 🟠 MED `docker/login-action` (job `create-manifest`)
- ⚪ LOW `actions/checkout` (job `metadata`)
- ⚪ LOW `actions/checkout` (job `build-amd64`)
- ⚪ LOW `actions/checkout` (job `build-arm64`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -16,13 +16,13 @@
       owner: ${{ steps.lowercase.outputs.owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Convert owner to lowercase
         id: lowercase
         run: echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: |
             ghcr.io/${{ steps.lowercase.outputs.owner }}/cloudflare-tunnel-ingress-controller
@@ -40,17 +40,17 @@
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ needs.metadata.outputs.owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push AMD64
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           file: image/cloudflare-tunnel-ingress-controller/Dockerfile
           platforms: linux/amd64
... (31 more diff lines — see Files changed)
```

</details>

### `.github/workflows/release-helm.yaml`

- 🟠 MED `stefanprodan/helm-gh-pages` (job `release-chart`)
- ⚪ LOW `actions/checkout` (job `release-chart`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -11,7 +11,7 @@
   release-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: "Extract Version"
         id: extract_version
         run: |
@@ -19,7 +19,7 @@
           VERSION=${GIT_TAG##v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Publish Helm chart
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@89c6698c192e70ed0e495bee7d3d1ca5b477fe82
         with:
           token: ${{ secrets.HELM_TOKEN }}
           charts_dir: helm
```

</details>

### `.github/workflows/unit-test.yaml`

- 🟠 MED `codecov/codecov-action` (job `unit-test`)
- ⚪ LOW `actions/checkout` (job `unit-test`)
- ⚪ LOW `actions/setup-go` (job `unit-test`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,15 +14,15 @@
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: './go.mod'
       - name: Run unit tests
         run: |
           make unit-test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ./cover.out
           flags: unit
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
