### PR TITLE
fix(controller): return error when ingress rule has host but nil HTTP

### DIFF
--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -28,6 +28,10 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			return nil, errors.Errorf("host in ingress %s/%s is empty", ingress.GetNamespace(), ingress.GetName())
 		}
 
+		if rule.HTTP == nil {
+			return nil, errors.Errorf("ingress rule for host %s has no http paths defined", rule.Host)
+		}
+
 		hostname := rule.Host
 		scheme := "http"
 

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -28,8 +28,14 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			return nil, errors.Errorf("host in ingress %s/%s is empty", ingress.GetNamespace(), ingress.GetName())
 		}
 
+		// rule.HTTP is optional in the Ingress API, a rule may carry only a
+		// host, skip it and keep processing the remaining rules
 		if rule.HTTP == nil {
-			return nil, errors.Errorf("ingress rule for host %s has no http paths defined", rule.Host)
+			logger.Info("ingress rule has no http section, skipped",
+				"ingress", fmt.Sprintf("%s/%s", ingress.GetNamespace(), ingress.GetName()),
+				"host", rule.Host,
+			)
+			continue
 		}
 
 		hostname := rule.Host

--- a/pkg/controller/transform_test.go
+++ b/pkg/controller/transform_test.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -127,5 +130,32 @@ func TestGetHostFromService(t *testing.T) {
 				t.Errorf("getHostFromService() returns unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestFromIngressToExposureNilHTTP(t *testing.T) {
+	// An Ingress rule may set a host while leaving HTTP nil (valid for
+	// TLS/SNI-only routing). Previously this dereferenced the nil pointer
+	// and panicked; it must return an error instead.
+	ingress := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "tls-only",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: nil,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := FromIngressToExposure(context.Background(), logr.Discard(), nil, ingress, "cluster.local")
+	if err == nil {
+		t.Fatalf("expected an error for a rule with nil HTTP, got nil")
 	}
 }

--- a/pkg/controller/transform_test.go
+++ b/pkg/controller/transform_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetHostFromService(t *testing.T) {
@@ -134,13 +135,13 @@ func TestGetHostFromService(t *testing.T) {
 }
 
 func TestFromIngressToExposureNilHTTP(t *testing.T) {
-	// An Ingress rule may set a host while leaving HTTP nil (valid for
-	// TLS/SNI-only routing). Previously this dereferenced the nil pointer
-	// and panicked; it must return an error instead.
+	// rule.HTTP is optional in the Ingress API, a rule may carry only a
+	// host. Previously this dereferenced the nil pointer and panicked;
+	// such rules must be skipped without failing the whole ingress.
 	ingress := networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      "tls-only",
+			Name:      "host-only",
 		},
 		Spec: networkingv1.IngressSpec{
 			Rules: []networkingv1.IngressRule{
@@ -154,8 +155,74 @@ func TestFromIngressToExposureNilHTTP(t *testing.T) {
 		},
 	}
 
-	_, err := FromIngressToExposure(context.Background(), logr.Discard(), nil, ingress, "cluster.local")
-	if err == nil {
-		t.Fatalf("expected an error for a rule with nil HTTP, got nil")
+	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), nil, ingress, "cluster.local")
+	if err != nil {
+		t.Fatalf("expected a rule with nil HTTP to be skipped, got error: %v", err)
+	}
+	if len(exposures) != 0 {
+		t.Fatalf("expected no exposures for a rule with nil HTTP, got %d", len(exposures))
+	}
+}
+
+func TestFromIngressToExposureNilHTTPKeepsOtherRules(t *testing.T) {
+	// A host-only rule must not drop the valid rules of the same ingress.
+	pathType := networkingv1.PathTypePrefix
+	ingress := networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "mixed-rules",
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "app.example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &pathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "my-app",
+											Port: networkingv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Host: "placeholder.example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: nil,
+					},
+				},
+			},
+		},
+	}
+
+	service := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-app",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Ports:     []v1.ServicePort{{Port: 80}},
+		},
+	}
+	kubeClient := fake.NewClientBuilder().WithObjects(&service).Build()
+
+	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), kubeClient, ingress, "cluster.local")
+	if err != nil {
+		t.Fatalf("expected the host-only rule to be skipped, got error: %v", err)
+	}
+	if len(exposures) != 1 {
+		t.Fatalf("expected exactly the valid rule to be exposed, got %d exposures", len(exposures))
+	}
+	if exposures[0].Hostname != "app.example.com" {
+		t.Fatalf("expected exposure for app.example.com, got %s", exposures[0].Hostname)
 	}
 }


### PR DESCRIPTION
Closing: the fix is complete and the package-level tests pass locally (nil-guard against panicking on ingress rules with host but no HTTP block). The upstream CI run is gated on maintainer approval for fork PRs, which is outside the author's control. Raised again if/when the maintainer enables workflow runs for forks.