### PR TITLE
feat: emit Kubernetes events for skipped and failed ingress rules

### DIFF
--- a/helm/cloudflare-tunnel-ingress-controller/templates/clusterrole.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/clusterrole.yaml
@@ -39,3 +39,10 @@ rules:
       - watch
       - update
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/pkg/controller/bootstrap.go
+++ b/pkg/controller/bootstrap.go
@@ -16,7 +16,7 @@ type IngressControllerOptions struct {
 }
 
 func RegisterIngressController(logger logr.Logger, mgr manager.Manager, options IngressControllerOptions) error {
-	controller := NewIngressController(logger.WithName("ingress-controller"), mgr.GetClient(), options.IngressClassName, options.ControllerClassName, options.ClusterDomain, options.CFTunnelClient)
+	controller := NewIngressController(logger.WithName("ingress-controller"), mgr.GetClient(), mgr.GetEventRecorderFor("cloudflare-tunnel-ingress-controller"), options.IngressClassName, options.ControllerClassName, options.ClusterDomain, options.CFTunnelClient)
 	err := builder.
 		ControllerManagedBy(mgr).
 		For(&networkingv1.Ingress{}).

--- a/pkg/controller/ingress-controller.go
+++ b/pkg/controller/ingress-controller.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -25,14 +26,15 @@ const IngressControllerFinalizer = "strrl.dev/cloudflare-tunnel-ingress-controll
 type IngressController struct {
 	logger              logr.Logger
 	kubeClient          client.Client
+	recorder            record.EventRecorder
 	ingressClassName    string
 	controllerClassName string
 	clusterDomain       string
 	tunnelClient        *cloudflarecontroller.TunnelClient
 }
 
-func NewIngressController(logger logr.Logger, kubeClient client.Client, ingressClassName string, controllerClassName string, clusterDomain string, tunnelClient *cloudflarecontroller.TunnelClient) *IngressController {
-	return &IngressController{logger: logger, kubeClient: kubeClient, ingressClassName: ingressClassName, controllerClassName: controllerClassName, clusterDomain: clusterDomain, tunnelClient: tunnelClient}
+func NewIngressController(logger logr.Logger, kubeClient client.Client, recorder record.EventRecorder, ingressClassName string, controllerClassName string, clusterDomain string, tunnelClient *cloudflarecontroller.TunnelClient) *IngressController {
+	return &IngressController{logger: logger, kubeClient: kubeClient, recorder: recorder, ingressClassName: ingressClassName, controllerClassName: controllerClassName, clusterDomain: clusterDomain, tunnelClient: tunnelClient}
 }
 
 func (i *IngressController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -82,9 +84,10 @@ func (i *IngressController) Reconcile(ctx context.Context, request reconcile.Req
 	var allExposures []exposure.Exposure
 	for _, ingress := range ingresses {
 		// best effort to extract exposures from all ingresses
-		exposures, err := FromIngressToExposure(ctx, i.logger, i.kubeClient, ingress, i.clusterDomain)
+		exposures, err := FromIngressToExposure(ctx, i.logger, i.kubeClient, i.recorder, ingress, i.clusterDomain)
 		if err != nil {
 			i.logger.Info("extract exposures from ingress, skipped", "triggered-by", request.NamespacedName, "ingress", fmt.Sprintf("%s/%s", ingress.Namespace, ingress.Name), "error", err)
+			i.recorder.Event(&ingress, v1.EventTypeWarning, EventReasonTransformFailed, err.Error())
 		}
 		allExposures = append(allExposures, exposures...)
 	}

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -12,14 +12,22 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 )
 
-func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient client.Client, ingress networkingv1.Ingress, clusterDomain string) ([]exposure.Exposure, error) {
+const (
+	EventReasonTLSIgnored      = "TLSIgnored"
+	EventReasonRuleSkipped     = "RuleSkipped"
+	EventReasonTransformFailed = "TransformFailed"
+)
+
+func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient client.Client, recorder record.EventRecorder, ingress networkingv1.Ingress, clusterDomain string) ([]exposure.Exposure, error) {
 	isDeleted := ingress.DeletionTimestamp != nil
 
 	if len(ingress.Spec.TLS) > 0 {
 		logger.Info("ingress has tls specified, SSL Passthrough is not supported, it will be ignored.")
+		recorder.Event(&ingress, v1.EventTypeWarning, EventReasonTLSIgnored, "ingress has tls specified, SSL Passthrough is not supported, it will be ignored")
 	}
 
 	var result []exposure.Exposure
@@ -35,6 +43,7 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				"ingress", fmt.Sprintf("%s/%s", ingress.GetNamespace(), ingress.GetName()),
 				"host", rule.Host,
 			)
+			recorder.Eventf(&ingress, v1.EventTypeWarning, EventReasonRuleSkipped, "rule for host %s has no http section, skipped", rule.Host)
 			continue
 		}
 

--- a/pkg/controller/transform_test.go
+++ b/pkg/controller/transform_test.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -155,12 +157,22 @@ func TestFromIngressToExposureNilHTTP(t *testing.T) {
 		},
 	}
 
-	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), nil, ingress, "cluster.local")
+	recorder := record.NewFakeRecorder(8)
+	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), nil, recorder, ingress, "cluster.local")
 	if err != nil {
 		t.Fatalf("expected a rule with nil HTTP to be skipped, got error: %v", err)
 	}
 	if len(exposures) != 0 {
 		t.Fatalf("expected no exposures for a rule with nil HTTP, got %d", len(exposures))
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, EventReasonRuleSkipped) {
+			t.Fatalf("expected a %s event, got %q", EventReasonRuleSkipped, event)
+		}
+	default:
+		t.Fatalf("expected a %s event to be recorded", EventReasonRuleSkipped)
 	}
 }
 
@@ -215,7 +227,7 @@ func TestFromIngressToExposureNilHTTPKeepsOtherRules(t *testing.T) {
 	}
 	kubeClient := fake.NewClientBuilder().WithObjects(&service).Build()
 
-	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), kubeClient, ingress, "cluster.local")
+	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), kubeClient, record.NewFakeRecorder(8), ingress, "cluster.local")
 	if err != nil {
 		t.Fatalf("expected the host-only rule to be skipped, got error: %v", err)
 	}

--- a/test/integration/controller/ingress_transform_test.go
+++ b/test/integration/controller/ingress_transform_test.go
@@ -14,6 +14,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 )
 
 const IntegrationTestNamespace = "cf-tunnel-ingress-controller-test"
@@ -25,6 +26,7 @@ var pathTypeImplementationSpecific = networkingv1.PathTypeImplementationSpecific
 
 var _ = Describe("transform ingress to exposure", func() {
 	logger := stdr.NewWithOptions(log.New(os.Stderr, "", log.LstdFlags), stdr.Options{LogCaller: stdr.All})
+	recorder := record.NewFakeRecorder(100)
 
 	It("should resolve ingress with PathType Prefix", func() {
 		// prepare
@@ -99,7 +101,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
@@ -183,7 +185,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).Should(HaveOccurred())
 		Expect(exposure).Should(BeNil())
 	})
@@ -261,7 +263,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).Should(HaveLen(1))
 	})
@@ -339,7 +341,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
@@ -423,7 +425,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).Should(HaveOccurred())
 		Expect(exposure).Should(BeNil())
 	})
@@ -501,7 +503,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).Should(HaveOccurred())
 		Expect(exposure).Should(BeNil())
 	})
@@ -582,7 +584,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
@@ -671,7 +673,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
@@ -756,7 +758,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure with custom cluster domain")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))
@@ -844,7 +846,7 @@ var _ = Describe("transform ingress to exposure", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("transforming ingress to exposure")
-		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, ingress, testClusterDomain)
+		exposure, err := controller.FromIngressToExposure(ctx, logger, kubeClient, recorder, ingress, testClusterDomain)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(exposure).ShouldNot(BeNil())
 		Expect(exposure).Should(HaveLen(1))


### PR DESCRIPTION
## Problem

The Ingress API has no status conditions, so when the controller hits unsupported configuration (a host-only rule, a tls section, a headless service, an unsupported pathType) it only writes its own logs and silently skips. `kubectl describe ingress` shows nothing; users have to dig through controller pod logs to learn why their ingress is not effective.

## Solution

Follow the ingress-nginx convention: emit Warning events on the Ingress object, directly visible via `kubectl describe ingress`.

## Major Changes

- event emission with three reasons
  - `RuleSkipped`: a rule carries only a host and no http section
  - `TLSIgnored`: the ingress has a tls section (SSL Passthrough unsupported)
  - `TransformFailed`: any transform error skipped by the best effort loop (covers headless services, unsupported pathType, missing services, etc.)
- wiring
  - `IngressController` gains a `record.EventRecorder`, injected via `mgr.GetEventRecorderFor(...)` in bootstrap
- Helm RBAC
  - ClusterRole gains create/patch on events; only the namespaced Role had them before, while ingresses live in arbitrary namespaces
- tests
  - unit test asserts the `RuleSkipped` event is recorded; integration tests switched to a `FakeRecorder`, 16/16 passing

## Example

```
$ kubectl describe ingress mixed-rules
Events:
  Warning  RuleSkipped  ...  rule for host placeholder.example.com has no http section, skipped
```