### PR TITLE
ci: replace floating branch refs with version tags and track actions via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       go-deps:
         patterns:
           - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -41,7 +41,7 @@ jobs:
           # model: "claude-opus-4-20250514"
           
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -55,7 +55,7 @@ jobs:
           # use_sticky_comment: true
           
           # Optional: Customize review based on file types
-          # direct_prompt: |
+          # prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
           #   - For API endpoints: Security, input validation, and error handling
@@ -63,7 +63,7 @@ jobs:
           #   - For tests: Coverage, edge cases, and test quality
           
           # Optional: Different prompts for different authors
-          # direct_prompt: |
+          # prompt: |
           #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -30,7 +30,7 @@ jobs:
           version: 'latest'
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@v0
         with:
           driver: docker
           container-runtime: docker

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -19,7 +19,7 @@ jobs:
           VERSION=${GIT_TAG##v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Publish Helm chart
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           token: ${{ secrets.HELM_TOKEN }}
           charts_dir: helm


### PR DESCRIPTION
## Problem

Four workflow references point at moving branches (`claude-code-action@beta` x2, `helm-gh-pages@master`, `setup-minikube@latest`). Branch refs change on every upstream push, making them the largest supply chain surface in the workflows: there is no review step between upstream pushing code and our CI executing it with repository secrets. We evaluated full SHA pinning (#312) and declined it to keep receiving upstream updates; this is the middle route.

## Solution

Replace branch refs with version tags, and let dependabot track all action versions weekly so updates keep arriving as reviewable PRs. Combined with the repository-level actions allowlist (configured separately in settings), workflows stay current without executing unreviewed upstream pushes.

## Major Changes

- workflow refs
  - `anthropics/claude-code-action`: `@beta` (stale branch, last updated Aug 2025) to `@v1` stable; v1 renames `direct_prompt` to `prompt`, migrated accordingly
  - `medyagh/setup-minikube`: `@latest` to `@v0`
  - `stefanprodan/helm-gh-pages`: `@master` to `@v1.7.0`
- dependabot
  - new `github-actions` ecosystem entry, weekly, grouped into a single PR