### PR TITLE
fix: omit tunnel rule path for non http backend protocols

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -24,6 +24,12 @@ jobs:
         with:
           go-version-file: './go.mod'
 
+      - name: Install cloudflared
+        run: |
+          curl -fsSL -o /tmp/cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+          sudo install /tmp/cloudflared /usr/local/bin/cloudflared
+          cloudflared --version
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:

--- a/pkg/cloudflare-controller/transform.go
+++ b/pkg/cloudflare-controller/transform.go
@@ -17,8 +17,13 @@ func fromExposureToCloudflareIngress(ctx context.Context, exposure exposure.Expo
 
 	result := cloudflare.UnvalidatedIngressRule{
 		Hostname: exposure.Hostname,
-		Path:     exposure.PathPrefix,
 		Service:  exposure.ServiceTarget,
+	}
+
+	// path based routing only applies to http(s), non http protocols
+	// like ssh, rdp or tcp must not carry a path in the tunnel rule
+	if strings.HasPrefix(exposure.ServiceTarget, "http://") || strings.HasPrefix(exposure.ServiceTarget, "https://") {
+		result.Path = exposure.PathPrefix
 	}
 
 	if exposure.HTTPHostHeader != nil {

--- a/pkg/cloudflare-controller/transform_test.go
+++ b/pkg/cloudflare-controller/transform_test.go
@@ -52,6 +52,44 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "ssh scheme drops path",
+			args: args{
+				ctx: context.Background(),
+				exposure: exposure.Exposure{
+					Hostname:      "ssh.example.com",
+					ServiceTarget: "ssh://10.0.0.1:22",
+					PathPrefix:    "/*",
+					IsDeleted:     false,
+				},
+			},
+			want: &cloudflare.UnvalidatedIngressRule{
+				Hostname:      "ssh.example.com",
+				Path:          "",
+				Service:       "ssh://10.0.0.1:22",
+				OriginRequest: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "tcp scheme drops path",
+			args: args{
+				ctx: context.Background(),
+				exposure: exposure.Exposure{
+					Hostname:      "tcp.example.com",
+					ServiceTarget: "tcp://10.0.0.1:5432",
+					PathPrefix:    "/",
+					IsDeleted:     false,
+				},
+			},
+			want: &cloudflare.UnvalidatedIngressRule{
+				Hostname:      "tcp.example.com",
+				Path:          "",
+				Service:       "tcp://10.0.0.1:5432",
+				OriginRequest: nil,
+			},
+			wantErr: false,
+		},
+		{
 			name: "contains path",
 			args: args{
 				ctx: context.Background(),

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -30,6 +30,10 @@ finish() {
         --namespace kubernetes-dashboard \
         --ignore-not-found=true \
         --wait=true
+    kubectl delete ingress redis-via-cloudflare-tcp \
+        --namespace default \
+        --ignore-not-found=true \
+        --wait=true
     minikube -p "$E2E_MINIKUBE_PROFILE" addons disable dashboard
     minikube -p "$E2E_MINIKUBE_PROFILE" addons disable metrics-server
     helm uninstall cf-ic-e2e \

--- a/test/e2e/happy_path_test.go
+++ b/test/e2e/happy_path_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -17,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -26,6 +29,11 @@ var _ = Describe("Happy Path", func() {
 		controllerReleaseName = "cf-ic-e2e"
 		dashboardNamespace    = "kubernetes-dashboard"
 		dashboardIngressName  = "dashboard-via-cloudflare"
+		redisNamespace        = "default"
+		redisName             = "e2e-redis"
+		redisPort             = int32(6379)
+		tcpIngressName        = "redis-via-cloudflare-tcp"
+		redisLocalAddr        = "127.0.0.1:16379"
 	)
 
 	It("exposes the Kubernetes dashboard via Cloudflare Tunnel", func() {
@@ -205,12 +213,167 @@ var _ = Describe("Happy Path", func() {
 			_, _ = fmt.Fprintf(GinkgoWriter, "dashboard screenshot saved to %s\n", path)
 		}
 
+		By("deploying a redis instance for the tcp exposure")
+		Expect(createRedis(redisNamespace, redisName)).To(Succeed())
+		waitFor("redis deployment ready", 5*time.Minute, 5*time.Second, func() error {
+			deployment, err := kubeClient.AppsV1().Deployments(redisNamespace).Get(context.Background(), redisName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if !isDeploymentAvailable(*deployment) {
+				return fmt.Errorf("redis deployment has %d available replicas", deployment.Status.AvailableReplicas)
+			}
+			return nil
+		})
+
+		By("creating an Ingress exposing redis with backend-protocol tcp")
+		_ = kubeClient.NetworkingV1().Ingresses(redisNamespace).Delete(context.Background(), tcpIngressName, metav1.DeleteOptions{})
+		tcpIngress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tcpIngressName,
+				Namespace: redisNamespace,
+				Annotations: map[string]string{
+					"cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol": "tcp",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: ptr.To("cloudflare-tunnel"),
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: tcpHostname,
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/",
+										PathType: &pathType,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: redisName,
+												Port: networkingv1.ServiceBackendPort{Number: redisPort},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = kubeClient.NetworkingV1().Ingresses(redisNamespace).Create(context.Background(), tcpIngress, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for the tcp ingress status to include the Cloudflare tunnel hostname")
+		waitFor("tcp ingress status hostname", 10*time.Minute, 10*time.Second, func() error {
+			current, err := kubeClient.NetworkingV1().Ingresses(redisNamespace).Get(context.Background(), tcpIngressName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if len(current.Status.LoadBalancer.Ingress) == 0 {
+				return fmt.Errorf("tcp ingress status has no entries yet")
+			}
+			return nil
+		})
+
+		By("reaching redis through the tunnel via cloudflared access tcp")
+		accessCtx, cancelAccess := context.WithCancel(suiteCtx)
+		accessCmd := exec.CommandContext(accessCtx, "cloudflared", "access", "tcp", "--hostname", tcpHostname, "--url", redisLocalAddr)
+		accessCmd.Stdout = GinkgoWriter
+		accessCmd.Stderr = GinkgoWriter
+		Expect(accessCmd.Start()).To(Succeed())
+		defer func() {
+			cancelAccess()
+			_ = accessCmd.Wait()
+		}()
+
+		waitFor("redis PING via tunnel", 15*time.Minute, 20*time.Second, func() error {
+			return redisPing(redisLocalAddr)
+		})
+
 		By("collecting coverage data from the controller pod")
 		if err := collectControllerCoverage(controllerNamespace, controllerReleaseName); err != nil {
 			_, _ = fmt.Fprintf(GinkgoWriter, "warning: failed to collect coverage: %v\n", err)
 		}
 	})
 })
+
+func createRedis(namespace string, name string) error {
+	labels := map[string]string{"app": name}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "redis",
+							Image: "redis:7-alpine",
+							Ports: []corev1.ContainerPort{{ContainerPort: 6379}},
+						},
+					},
+				},
+			},
+		},
+	}
+	if _, err := kubeClient.AppsV1().Deployments(namespace).Create(context.Background(), deployment, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create redis deployment: %w", err)
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       6379,
+					TargetPort: intstr.FromInt32(6379),
+				},
+			},
+		},
+	}
+	if _, err := kubeClient.CoreV1().Services(namespace).Create(context.Background(), service, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create redis service: %w", err)
+	}
+	return nil
+}
+
+// redisPing dials the local forwarder opened by cloudflared access tcp and
+// performs a real PING round-trip through the Cloudflare edge and the tunnel.
+func redisPing(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := conn.SetDeadline(time.Now().Add(15 * time.Second)); err != nil {
+		return err
+	}
+	if _, err := conn.Write([]byte("PING\r\n")); err != nil {
+		return err
+	}
+	buffer := make([]byte, 64)
+	n, err := conn.Read(buffer)
+	if err != nil {
+		return err
+	}
+	response := strings.TrimSpace(string(buffer[:n]))
+	if response != "+PONG" {
+		return fmt.Errorf("unexpected redis response %q", response)
+	}
+	return nil
+}
 
 func isNodeReady(node corev1.Node) bool {
 	for _, condition := range node.Status.Conditions {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -32,6 +32,7 @@ var (
 	controllerImageRef  imageRef
 	dashboardBaseDomain string
 	dashboardHostname   string
+	tcpHostname         string
 )
 
 var requiredEnvVars = []string{
@@ -77,9 +78,12 @@ var _ = BeforeSuite(func() {
 	controllerImageRef, err = parseImageRef(controllerImage)
 	Expect(err).NotTo(HaveOccurred(), "parse controller image reference")
 	dashboardBaseDomain = os.Getenv(dashboardBaseDomainEnvKey)
-	dashboardHostname, err = buildDashboardHostname(dashboardBaseDomain)
+	dashboardHostname, err = buildTestHostname("cf-dashboard", dashboardBaseDomain)
 	Expect(err).NotTo(HaveOccurred(), "build dashboard hostname")
 	_, _ = fmt.Fprintf(GinkgoWriter, "using dashboard hostname %s\n", dashboardHostname)
+	tcpHostname, err = buildTestHostname("cf-tcp", dashboardBaseDomain)
+	Expect(err).NotTo(HaveOccurred(), "build tcp hostname")
+	_, _ = fmt.Fprintf(GinkgoWriter, "using tcp hostname %s\n", tcpHostname)
 
 	verifyCtx, cancel := context.WithTimeout(suiteCtx, 30*time.Second)
 	defer cancel()
@@ -90,6 +94,9 @@ var _ = BeforeSuite(func() {
 
 	_, err = exec.LookPath("helm")
 	Expect(err).NotTo(HaveOccurred(), "helm binary must be installed and on PATH")
+
+	_, err = exec.LookPath("cloudflared")
+	Expect(err).NotTo(HaveOccurred(), "cloudflared binary must be installed and on PATH")
 
 	minikubeProfile = os.Getenv(e2eMinikubeProfileEnvKey)
 	kubeconfigPath = os.Getenv(e2eKubeconfigEnvKey)
@@ -351,7 +358,7 @@ func enableMinikubeAddon(ctx context.Context, profile string, addon string) erro
 	return nil
 }
 
-func buildDashboardHostname(baseDomain string) (string, error) {
+func buildTestHostname(prefix string, baseDomain string) (string, error) {
 	trimmed := strings.TrimSpace(baseDomain)
 	trimmed = strings.TrimPrefix(trimmed, "https://")
 	trimmed = strings.TrimPrefix(trimmed, "http://")
@@ -363,7 +370,7 @@ func buildDashboardHostname(baseDomain string) (string, error) {
 	if strings.Contains(trimmed, "/") {
 		return "", fmt.Errorf("base domain %s must not contain path", trimmed)
 	}
-	label := fmt.Sprintf("cf-dashboard-%d", time.Now().UnixNano())
+	label := fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 	return fmt.Sprintf("%s.%s", label, trimmed), nil
 }
 


### PR DESCRIPTION
## Problem

Path based routing only exists for http(s) in cloudflare tunnel ingress rules. For backend protocols like ssh, rdp or tcp the Ingress spec still requires a dummy http path entry, which previously leaked into the tunnel rule and broke the tunnel for those protocols.

## Solution

Only set `Path` on the tunnel rule when the service target scheme is http or https. Covers ssh, tcp, rdp and any future non http protocol in one place.

## Major Changes

- pkg/cloudflare-controller/transform.go
  - `Path` is set only for `http://` and `https://` service targets
  - tests for ssh and tcp exposures asserting the path is dropped

Supersedes #178 — credit to @lalyos for identifying the issue.