### PR TITLE
feat: relinquish DNS ownership when management is disabled

### DIFF
--- a/pkg/cloudflare-controller/dns.go
+++ b/pkg/cloudflare-controller/dns.go
@@ -71,14 +71,35 @@ func syncDNSRecord(
 
 	// Create or update CNAME/TXT records for active exposures
 	for _, item := range effectiveExposures {
-		// DNS management is delegated externally for this exposure: skip creating or
-		// updating its records. It stays in effectiveExposures so the deletion pass
-		// below still treats its hostname as known and leaves existing records alone.
+		txtRecordName := fmt.Sprintf("%s.%s", ManagedRecordTXTPrefix, item.Hostname)
+
+		// DNS management is delegated externally for this exposure: relinquish
+		// ownership by cleaning up the records this controller created, so a
+		// later ingress deletion can never claim an externally managed record.
+		// The CNAME is only removed while it still points at this tunnel, if an
+		// external system already repointed it the record must survive and only
+		// the ownership TXT is dropped.
 		if item.DisableDNSManagement {
+			containsTXT, oldTXT := dnsRecordsContainsHostname(existedTXTRecords, txtRecordName)
+			if containsTXT && oldTXT.Content == expectedTXTContent {
+				containsCNAME, oldCNAME := dnsRecordsContainsHostname(existedCNAMERecords, item.Hostname)
+				if containsCNAME && oldCNAME.Content == tunnelDomain(tunnelId) {
+					toDelete = append(toDelete, DNSOperationDelete{
+						OldRecord: oldCNAME,
+					})
+					logger.Info("DNS management disabled, deleting controller-owned CNAME record",
+						"hostname", item.Hostname,
+					)
+				}
+				toDelete = append(toDelete, DNSOperationDelete{
+					OldRecord: oldTXT,
+				})
+				logger.Info("DNS management disabled, relinquishing ownership TXT record",
+					"hostname", item.Hostname,
+				)
+			}
 			continue
 		}
-
-		txtRecordName := fmt.Sprintf("%s.%s", ManagedRecordTXTPrefix, item.Hostname)
 
 		// Handle CNAME record
 		containsCNAME, oldCNAME := dnsRecordsContainsHostname(existedCNAMERecords, item.Hostname)

--- a/pkg/cloudflare-controller/dns_test.go
+++ b/pkg/cloudflare-controller/dns_test.go
@@ -359,7 +359,7 @@ func Test_syncDNSRecord(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "exposure with DNS management disabled does not delete existing record",
+			name: "exposure with DNS management disabled relinquishes owned records",
 			args: args{
 				logger: logr.Discard(),
 				exposures: []exposure.Exposure{
@@ -383,6 +383,99 @@ func Test_syncDNSRecord(t *testing.T) {
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
 						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exposure with DNS management disabled keeps a repointed CNAME and only drops the ownership TXT",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:             "test.example.com",
+						ServiceTarget:        "http://10.0.0.1:233",
+						PathPrefix:           "/",
+						IsDeleted:            false,
+						DisableDNSManagement: true,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: "load-balancer.example.net",
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "exposure with DNS management disabled ignores records owned by another tunnel",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:             "test.example.com",
+						ServiceTarget:        "http://10.0.0.1:233",
+						PathPrefix:           "/",
+						IsDeleted:            false,
+						DisableDNSManagement: true,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: "other-tunnel.cfargotunnel.com",
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"another-tunnel"}`,
 					},
 				},
 				tunnelId:   WhateverTunnelId,

--- a/test/e2e/cloudflare_dns.go
+++ b/test/e2e/cloudflare_dns.go
@@ -1,0 +1,50 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+)
+
+func newCloudflareAPI() (*cloudflare.API, error) {
+	return cloudflare.NewWithAPIToken(os.Getenv("CLOUDFLARE_API_TOKEN"))
+}
+
+// findZoneID resolves the zone covering the hostname by picking the longest
+// zone name that is a suffix of the hostname.
+func findZoneID(ctx context.Context, api *cloudflare.API, hostname string) (string, error) {
+	zones, err := api.ListZones(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list zones: %w", err)
+	}
+
+	var bestID string
+	var bestName string
+	for _, zone := range zones {
+		if hostname != zone.Name && !strings.HasSuffix(hostname, "."+zone.Name) {
+			continue
+		}
+		if len(zone.Name) > len(bestName) {
+			bestID = zone.ID
+			bestName = zone.Name
+		}
+	}
+	if bestID == "" {
+		return "", fmt.Errorf("no zone found for hostname %s", hostname)
+	}
+	return bestID, nil
+}
+
+func dnsRecordExists(ctx context.Context, api *cloudflare.API, zoneID string, recordType string, name string) (bool, error) {
+	records, _, err := api.ListDNSRecords(ctx, cloudflare.ResourceIdentifier(zoneID), cloudflare.ListDNSRecordsParams{
+		Type: recordType,
+		Name: name,
+	})
+	if err != nil {
+		return false, fmt.Errorf("list %s records for %s: %w", recordType, name, err)
+	}
+	return len(records) > 0, nil
+}

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -38,6 +38,10 @@ finish() {
         --namespace default \
         --ignore-not-found=true \
         --wait=true
+    kubectl delete ingress dns-managed-via-cloudflare \
+        --namespace default \
+        --ignore-not-found=true \
+        --wait=true
     minikube -p "$E2E_MINIKUBE_PROFILE" addons disable dashboard
     minikube -p "$E2E_MINIKUBE_PROFILE" addons disable metrics-server
     helm uninstall cf-ic-e2e \

--- a/test/e2e/happy_path_test.go
+++ b/test/e2e/happy_path_test.go
@@ -38,6 +38,9 @@ var _ = Describe("Happy Path", func() {
 		exactEchoName         = "e2e-echo-exact"
 		fallbackEchoName      = "e2e-echo-fallback"
 		wildcardIngressName   = "wildcard-routing-via-cloudflare"
+		dnsEchoNamespace      = "default"
+		dnsEchoName           = "e2e-echo-dns"
+		dnsIngressName        = "dns-managed-via-cloudflare"
 	)
 
 	It("exposes the Kubernetes dashboard via Cloudflare Tunnel", func() {
@@ -348,6 +351,96 @@ var _ = Describe("Happy Path", func() {
 		By("verifying an unmatched subdomain falls back to the wildcard backend")
 		waitFor("wildcard fallback routing", 15*time.Minute, 20*time.Second, func() error {
 			return expectHTTPBody(client, fmt.Sprintf("https://%s/", probeHostname), "wildcard-backend")
+		})
+
+		By("exposing an echo service with managed DNS records")
+		Expect(createHTTPEcho(dnsEchoNamespace, dnsEchoName, "dns-managed-backend")).To(Succeed())
+		waitFor(fmt.Sprintf("%s deployment ready", dnsEchoName), 5*time.Minute, 5*time.Second, func() error {
+			deployment, err := kubeClient.AppsV1().Deployments(dnsEchoNamespace).Get(context.Background(), dnsEchoName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if !isDeploymentAvailable(*deployment) {
+				return fmt.Errorf("%s deployment has %d available replicas", dnsEchoName, deployment.Status.AvailableReplicas)
+			}
+			return nil
+		})
+
+		dnsHostname, err := buildTestHostname("cf-dns", dashboardBaseDomain)
+		Expect(err).NotTo(HaveOccurred())
+		ownershipTXTName := "_ctic_managed." + dnsHostname
+
+		_ = kubeClient.NetworkingV1().Ingresses(dnsEchoNamespace).Delete(context.Background(), dnsIngressName, metav1.DeleteOptions{})
+		dnsIngress := &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dnsIngressName,
+				Namespace: dnsEchoNamespace,
+			},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: ptr.To("cloudflare-tunnel"),
+				Rules: []networkingv1.IngressRule{
+					echoIngressRule(dnsHostname, dnsEchoName, &pathType),
+				},
+			},
+		}
+		_, err = kubeClient.NetworkingV1().Ingresses(dnsEchoNamespace).Create(context.Background(), dnsIngress, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the controller created the CNAME and ownership TXT records")
+		cfAPI, err := newCloudflareAPI()
+		Expect(err).NotTo(HaveOccurred())
+		zoneID, err := findZoneID(context.Background(), cfAPI, dnsHostname)
+		Expect(err).NotTo(HaveOccurred())
+
+		waitFor("managed DNS records created", 10*time.Minute, 10*time.Second, func() error {
+			cnameExists, err := dnsRecordExists(context.Background(), cfAPI, zoneID, "CNAME", dnsHostname)
+			if err != nil {
+				return err
+			}
+			if !cnameExists {
+				return fmt.Errorf("CNAME record for %s not created yet", dnsHostname)
+			}
+			txtExists, err := dnsRecordExists(context.Background(), cfAPI, zoneID, "TXT", ownershipTXTName)
+			if err != nil {
+				return err
+			}
+			if !txtExists {
+				return fmt.Errorf("ownership TXT record for %s not created yet", dnsHostname)
+			}
+			return nil
+		})
+
+		By("disabling DNS management on the ingress via annotation")
+		waitFor("annotate ingress", 2*time.Minute, 5*time.Second, func() error {
+			current, err := kubeClient.NetworkingV1().Ingresses(dnsEchoNamespace).Get(context.Background(), dnsIngressName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if current.Annotations == nil {
+				current.Annotations = map[string]string{}
+			}
+			current.Annotations["cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management"] = "true"
+			_, err = kubeClient.NetworkingV1().Ingresses(dnsEchoNamespace).Update(context.Background(), current, metav1.UpdateOptions{})
+			return err
+		})
+
+		By("verifying the controller relinquished its DNS records")
+		waitFor("managed DNS records relinquished", 10*time.Minute, 10*time.Second, func() error {
+			cnameExists, err := dnsRecordExists(context.Background(), cfAPI, zoneID, "CNAME", dnsHostname)
+			if err != nil {
+				return err
+			}
+			if cnameExists {
+				return fmt.Errorf("CNAME record for %s still present", dnsHostname)
+			}
+			txtExists, err := dnsRecordExists(context.Background(), cfAPI, zoneID, "TXT", ownershipTXTName)
+			if err != nil {
+				return err
+			}
+			if txtExists {
+				return fmt.Errorf("ownership TXT record for %s still present", dnsHostname)
+			}
+			return nil
 		})
 
 		By("collecting coverage data from the controller pod")


### PR DESCRIPTION
## Problem

Follow-up to #311. The `disable-dns-management` annotation skipped record reconciliation but left the `_ctic_managed` ownership TXT behind. Timeline of the resulting footgun: ingress managed normally → annotation turned on → external-dns or a Cloudflare Load Balancer takes over the CNAME → months later the ingress is deleted → the deletion pass finds the stale TXT, claims the hostname and deletes the externally managed CNAME. The feature's own target audience is exactly who gets hit.

## Solution

A flagged exposure now actively relinquishes ownership instead of just going hands-off: the ownership TXT is deleted, and the controller-created CNAME is cleaned up only while it still points at this tunnel. A CNAME already repointed by an external system survives untouched. Records owned by another tunnel are never touched.

## Major Changes

- pkg/cloudflare-controller/dns.go
  - `syncDNSRecord`: the disable-dns-management branch queries controller-owned records for the hostname and emits delete operations for them, instead of skipping silently
- tests
  - relinquish of owned CNAME+TXT, repointed CNAME kept while TXT is dropped, records of another tunnel ignored

## Pending

An e2e scenario (create managed ingress → verify records via the Cloudflare API → enable the annotation → verify the records are cleaned up) will be added to this PR after #322 merges, it reuses the echo helpers introduced there.