### PR TITLE
chore: finish viper config loading follow up

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ kubectl -n kubernetes-dashboard \
 
 - Done! Enjoy! 🎉
 
+## Configuration
+
+The controller reads configuration from CLI flags and environment variables, with precedence: CLI flags > environment variables > built in defaults. Every flag maps to an environment variable by uppercasing the flag name and replacing `-` with `_`. This is handy for local debugging with an `.env` file, since flags and environment variables share a single config loading path.
+
+| Flag | Environment variable | Default |
+| --- | --- | --- |
+| `--cloudflare-api-token` | `CLOUDFLARE_API_TOKEN` | (required) |
+| `--cloudflare-account-id` | `CLOUDFLARE_ACCOUNT_ID` | (required) |
+| `--cloudflare-tunnel-name` | `CLOUDFLARE_TUNNEL_NAME` | (required) |
+| `--ingress-class` | `INGRESS_CLASS` | `cloudflare-tunnel` |
+| `--controller-class` | `CONTROLLER_CLASS` | `strrl.dev/cloudflare-tunnel-ingress-controller` |
+| `--log-level` | `LOG_LEVEL` | `0` |
+| `--namespace` | `NAMESPACE` | `default` |
+| `--cloudflared-protocol` | `CLOUDFLARED_PROTOCOL` | `auto` |
+| `--cloudflared-extra-args` | `CLOUDFLARED_EXTRA_ARGS` | (empty) |
+| `--cluster-domain` | `CLUSTER_DOMAIN` | `cluster.local` |
+| `--leader-elect` | `LEADER_ELECT` | `false` |
+| `--dns-comment-template` | `DNS_COMMENT_TEMPLATE` | `managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]` |
+
+The managed cloudflared connector deployment is configured with environment variables only:
+
+| Environment variable | Default |
+| --- | --- |
+| `CLOUDFLARED_IMAGE` | `cloudflare/cloudflared:latest` |
+| `CLOUDFLARED_IMAGE_PULL_POLICY` | `IfNotPresent` |
+| `CLOUDFLARED_REPLICA_COUNT` | `1` |
+
 ## Alternative
 
 There is also an awesome project which could integrate with Cloudflare Tunnel as CRD, check it out [adyanth/cloudflare-operator](https://github.com/adyanth/cloudflare-operator)!

--- a/README.md
+++ b/README.md
@@ -97,17 +97,12 @@ The controller reads configuration from CLI flags and environment variables, wit
 | `--namespace` | `NAMESPACE` | `default` |
 | `--cloudflared-protocol` | `CLOUDFLARED_PROTOCOL` | `auto` |
 | `--cloudflared-extra-args` | `CLOUDFLARED_EXTRA_ARGS` | (empty) |
+| `--cloudflared-image` | `CLOUDFLARED_IMAGE` | `cloudflare/cloudflared:latest` |
+| `--cloudflared-image-pull-policy` | `CLOUDFLARED_IMAGE_PULL_POLICY` | `IfNotPresent` |
+| `--cloudflared-replica-count` | `CLOUDFLARED_REPLICA_COUNT` | `1` |
 | `--cluster-domain` | `CLUSTER_DOMAIN` | `cluster.local` |
 | `--leader-elect` | `LEADER_ELECT` | `false` |
 | `--dns-comment-template` | `DNS_COMMENT_TEMPLATE` | `managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]` |
-
-The managed cloudflared connector deployment is configured with environment variables only:
-
-| Environment variable | Default |
-| --- | --- |
-| `CLOUDFLARED_IMAGE` | `cloudflare/cloudflared:latest` |
-| `CLOUDFLARED_IMAGE_PULL_POLICY` | `IfNotPresent` |
-| `CLOUDFLARED_REPLICA_COUNT` | `1` |
 
 ## Alternative
 

--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -75,6 +75,7 @@ func main() {
 			options.cloudflaredExtraArgs = viper.GetStringSlice("cloudflared-extra-args")
 			options.clusterDomain = viper.GetString("cluster-domain")
 			options.leaderElect = viper.GetBool("leader-elect")
+			options.dnsCommentTemplate = viper.GetString("dns-comment-template")
 
 			stdr.SetVerbosity(options.logLevel)
 			logger := options.logger
@@ -175,10 +176,6 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.clusterDomain, "cluster-domain", options.clusterDomain, "kubernetes cluster domain, used to build service FQDN (should match kubelet --cluster-domain)")
 	rootCommand.PersistentFlags().BoolVar(&options.leaderElect, "leader-elect", options.leaderElect, "enable leader election for high availability")
 	rootCommand.PersistentFlags().StringVar(&options.dnsCommentTemplate, "dns-comment-template", options.dnsCommentTemplate, "Go template for DNS record comments. Available variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}. Set to empty string to disable. Note: Cloudflare limits comment length by plan (Free: 100, Pro/Biz/Ent: 500 chars). See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/")
-
-	viper.SetDefault("cloudflared-image", "cloudflare/cloudflared:latest")
-	viper.SetDefault("cloudflared-image-pull-policy", "IfNotPresent")
-	viper.SetDefault("cloudflared-replica-count", 1)
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))

--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -28,17 +28,20 @@ type rootCmdFlags struct {
 	// for annotation on Ingress
 	ingressClass string
 	// for IngressClass.spec.controller
-	controllerClass      string
-	logLevel             int
-	cloudflareAPIToken   string
-	cloudflareAccountId  string
-	cloudflareTunnelName string
-	namespace            string
-	cloudflaredProtocol  string
-	cloudflaredExtraArgs []string
-	clusterDomain        string
-	leaderElect          bool
-	dnsCommentTemplate   string
+	controllerClass            string
+	logLevel                   int
+	cloudflareAPIToken         string
+	cloudflareAccountId        string
+	cloudflareTunnelName       string
+	namespace                  string
+	cloudflaredProtocol        string
+	cloudflaredExtraArgs       []string
+	cloudflaredImage           string
+	cloudflaredImagePullPolicy string
+	cloudflaredReplicaCount    int32
+	clusterDomain              string
+	leaderElect                bool
+	dnsCommentTemplate         string
 }
 
 func main() {
@@ -47,14 +50,17 @@ func main() {
 	var rootLogger = stdr.NewWithOptions(log.New(os.Stderr, "", log.LstdFlags), stdr.Options{LogCaller: stdr.All})
 
 	options := rootCmdFlags{
-		logger:              rootLogger.WithName("main"),
-		ingressClass:        "cloudflare-tunnel",
-		controllerClass:     "strrl.dev/cloudflare-tunnel-ingress-controller",
-		logLevel:            0,
-		namespace:           "default",
-		cloudflaredProtocol: "auto",
-		clusterDomain:       "cluster.local",
-		dnsCommentTemplate:  "managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]",
+		logger:                     rootLogger.WithName("main"),
+		ingressClass:               "cloudflare-tunnel",
+		controllerClass:            "strrl.dev/cloudflare-tunnel-ingress-controller",
+		logLevel:                   0,
+		namespace:                  "default",
+		cloudflaredProtocol:        "auto",
+		cloudflaredImage:           "cloudflare/cloudflared:latest",
+		cloudflaredImagePullPolicy: "IfNotPresent",
+		cloudflaredReplicaCount:    1,
+		clusterDomain:              "cluster.local",
+		dnsCommentTemplate:         "managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]",
 	}
 
 	crlog.SetLogger(rootLogger.WithName("controller-runtime"))
@@ -73,6 +79,9 @@ func main() {
 			options.namespace = viper.GetString("namespace")
 			options.cloudflaredProtocol = viper.GetString("cloudflared-protocol")
 			options.cloudflaredExtraArgs = viper.GetStringSlice("cloudflared-extra-args")
+			options.cloudflaredImage = viper.GetString("cloudflared-image")
+			options.cloudflaredImagePullPolicy = viper.GetString("cloudflared-image-pull-policy")
+			options.cloudflaredReplicaCount = viper.GetInt32("cloudflared-replica-count")
 			options.clusterDomain = viper.GetString("cluster-domain")
 			options.leaderElect = viper.GetBool("leader-elect")
 			options.dnsCommentTemplate = viper.GetString("dns-comment-template")
@@ -151,7 +160,13 @@ func main() {
 					case <-done:
 						return
 					case <-ticker.C:
-						err := controller.CreateOrUpdateControlledCloudflared(ctx, mgr.GetClient(), tunnelClient, options.namespace, options.cloudflaredProtocol, options.cloudflaredExtraArgs)
+						err := controller.CreateOrUpdateControlledCloudflared(ctx, mgr.GetClient(), tunnelClient, options.namespace, controller.CloudflaredConfig{
+							Image:           options.cloudflaredImage,
+							ImagePullPolicy: options.cloudflaredImagePullPolicy,
+							Replicas:        options.cloudflaredReplicaCount,
+							Protocol:        options.cloudflaredProtocol,
+							ExtraArgs:       options.cloudflaredExtraArgs,
+						})
 						if err != nil {
 							logger.WithName("controlled-cloudflared").Error(err, "create controlled cloudflared")
 						}
@@ -173,6 +188,9 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.namespace, "namespace", options.namespace, "namespace to execute cloudflared connector")
 	rootCommand.PersistentFlags().StringVar(&options.cloudflaredProtocol, "cloudflared-protocol", options.cloudflaredProtocol, "cloudflared protocol")
 	rootCommand.PersistentFlags().StringSliceVar(&options.cloudflaredExtraArgs, "cloudflared-extra-args", options.cloudflaredExtraArgs, "extra arguments to pass to cloudflared")
+	rootCommand.PersistentFlags().StringVar(&options.cloudflaredImage, "cloudflared-image", options.cloudflaredImage, "container image for the managed cloudflared connector")
+	rootCommand.PersistentFlags().StringVar(&options.cloudflaredImagePullPolicy, "cloudflared-image-pull-policy", options.cloudflaredImagePullPolicy, "image pull policy for the managed cloudflared connector")
+	rootCommand.PersistentFlags().Int32Var(&options.cloudflaredReplicaCount, "cloudflared-replica-count", options.cloudflaredReplicaCount, "replica count for the managed cloudflared connector")
 	rootCommand.PersistentFlags().StringVar(&options.clusterDomain, "cluster-domain", options.clusterDomain, "kubernetes cluster domain, used to build service FQDN (should match kubelet --cluster-domain)")
 	rootCommand.PersistentFlags().BoolVar(&options.leaderElect, "leader-elect", options.leaderElect, "enable leader election for high availability")
 	rootCommand.PersistentFlags().StringVar(&options.dnsCommentTemplate, "dns-comment-template", options.dnsCommentTemplate, "Go template for DNS record comments. Available variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}. Set to empty string to disable. Note: Cloudflare limits comment length by plan (Free: 100, Pro/Biz/Ent: 500 chars). See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/")

--- a/pkg/controller/controlled-cloudflared-connector.go
+++ b/pkg/controller/controlled-cloudflared-connector.go
@@ -3,11 +3,9 @@ package controller
 import (
 	"context"
 	"slices"
-	"strconv"
 
 	cloudflarecontroller "github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/cloudflare-controller"
 	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,13 +15,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// CloudflaredConfig carries the fully resolved settings for the managed
+// cloudflared connector deployment, configuration parsing stays in main.
+type CloudflaredConfig struct {
+	Image           string
+	ImagePullPolicy string
+	Replicas        int32
+	Protocol        string
+	ExtraArgs       []string
+}
+
 func CreateOrUpdateControlledCloudflared(
 	ctx context.Context,
 	kubeClient client.Client,
 	tunnelClient cloudflarecontroller.TunnelClientInterface,
 	namespace string,
-	protocol string,
-	extraArgs []string,
+	config CloudflaredConfig,
 ) error {
 	logger := log.FromContext(ctx)
 
@@ -50,26 +57,22 @@ func CreateOrUpdateControlledCloudflared(
 
 	if len(list.Items) > 0 {
 		existingDeployment := &list.Items[0]
-		desiredReplicas, err := getDesiredReplicas()
-		if err != nil {
-			return errors.Wrap(err, "get desired replicas")
-		}
 
 		needsUpdate := false
-		if *existingDeployment.Spec.Replicas != desiredReplicas {
+		if *existingDeployment.Spec.Replicas != config.Replicas {
 			needsUpdate = true
 		}
 
 		if len(existingDeployment.Spec.Template.Spec.Containers) > 0 {
 			container := &existingDeployment.Spec.Template.Spec.Containers[0]
-			if container.Image != cloudflaredImage() {
+			if container.Image != config.Image {
 				needsUpdate = true
 			}
-			if string(container.ImagePullPolicy) != cloudflaredImagePullPolicy() {
+			if string(container.ImagePullPolicy) != config.ImagePullPolicy {
 				needsUpdate = true
 			}
 
-			desiredCommand := buildCloudflaredCommand(protocol, extraArgs)
+			desiredCommand := buildCloudflaredCommand(config.Protocol, config.ExtraArgs)
 			if !slices.Equal(container.Command, desiredCommand) {
 				needsUpdate = true
 			}
@@ -80,11 +83,9 @@ func CreateOrUpdateControlledCloudflared(
 
 		if needsUpdate {
 			updatedDeployment := controlledCloudflaredDeployment{
-				protocol:           protocol,
+				config:             config,
 				tokenSecretVersion: tokenSecretVersion,
 				namespace:          namespace,
-				replicas:           desiredReplicas,
-				extraArgs:          extraArgs,
 			}.build()
 			existingDeployment.Spec = updatedDeployment.Spec
 			err = kubeClient.Update(ctx, existingDeployment)
@@ -97,17 +98,10 @@ func CreateOrUpdateControlledCloudflared(
 		return nil
 	}
 
-	replicas, err := getDesiredReplicas()
-	if err != nil {
-		return errors.Wrap(err, "get desired replicas")
-	}
-
 	deployment := controlledCloudflaredDeployment{
-		protocol:           protocol,
+		config:             config,
 		tokenSecretVersion: tokenSecretVersion,
 		namespace:          namespace,
-		replicas:           replicas,
-		extraArgs:          extraArgs,
 	}.build()
 	err = kubeClient.Create(ctx, deployment)
 	if err != nil {
@@ -172,18 +166,6 @@ func createOrUpdateTunnelTokenSecret(
 const tunnelTokenSecretName = "controlled-cloudflared-token"
 const tunnelTokenSecretKey = "tunnel-token"
 const tunnelTokenSecretVersionAnnotation = "strrl.dev/cloudflare-tunnel-token-secret-version"
-
-func getDesiredReplicas() (int32, error) {
-	raw := viper.GetString("cloudflared-replica-count")
-	if raw == "" {
-		return 1, nil
-	}
-	replicas, err := strconv.ParseInt(raw, 10, 32)
-	if err != nil {
-		return 0, errors.Wrap(err, "invalid replica count")
-	}
-	return int32(replicas), nil
-}
 
 func buildCloudflaredCommand(protocol string, extraArgs []string) []string {
 	command := []string{

--- a/pkg/controller/controlled-cloudflared-connector_test.go
+++ b/pkg/controller/controlled-cloudflared-connector_test.go
@@ -86,11 +86,3 @@ func TestBuildCloudflaredCommand(t *testing.T) {
 		})
 	}
 }
-
-func TestGetDesiredReplicasDefaultsToOne(t *testing.T) {
-	t.Setenv("CLOUDFLARED_REPLICA_COUNT", "")
-
-	replicas, err := getDesiredReplicas()
-	assert.NoError(t, err)
-	assert.Equal(t, int32(1), replicas)
-}

--- a/pkg/controller/controlled-cloudflared-deployment.go
+++ b/pkg/controller/controlled-cloudflared-deployment.go
@@ -1,39 +1,19 @@
 package controller
 
 import (
-	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func cloudflaredImage() string {
-	if image := viper.GetString("cloudflared-image"); image != "" {
-		return image
-	}
-	return "cloudflare/cloudflared:latest"
-}
-
-func cloudflaredImagePullPolicy() string {
-	if policy := viper.GetString("cloudflared-image-pull-policy"); policy != "" {
-		return policy
-	}
-	return "IfNotPresent"
-}
-
 type controlledCloudflaredDeployment struct {
-	protocol           string
+	config             CloudflaredConfig
 	tokenSecretVersion string
 	namespace          string
-	replicas           int32
-	extraArgs          []string
 }
 
 func (d controlledCloudflaredDeployment) build() *appsv1.Deployment {
 	const appName = "controlled-cloudflared-connector"
-
-	image := cloudflaredImage()
-	pullPolicy := cloudflaredImagePullPolicy()
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -45,7 +25,7 @@ func (d controlledCloudflaredDeployment) build() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &d.replicas,
+			Replicas: &d.config.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": appName,
@@ -67,9 +47,9 @@ func (d controlledCloudflaredDeployment) build() *appsv1.Deployment {
 					Containers: []v1.Container{
 						{
 							Name:            appName,
-							Image:           image,
-							ImagePullPolicy: v1.PullPolicy(pullPolicy),
-							Command:         buildCloudflaredCommand(d.protocol, d.extraArgs),
+							Image:           d.config.Image,
+							ImagePullPolicy: v1.PullPolicy(d.config.ImagePullPolicy),
+							Command:         buildCloudflaredCommand(d.config.Protocol, d.config.ExtraArgs),
 							Env: []v1.EnvVar{
 								{
 									Name: "TUNNEL_TOKEN",

--- a/pkg/controller/controlled-cloudflared-deployment_test.go
+++ b/pkg/controller/controlled-cloudflared-deployment_test.go
@@ -3,22 +3,22 @@ package controller
 import (
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 )
 
 func TestControlledCloudflaredDeploymentBuild(t *testing.T) {
-	viper.Reset()
-	t.Cleanup(viper.Reset)
-
 	deployment := controlledCloudflaredDeployment{
-		protocol:           "quic",
+		config: CloudflaredConfig{
+			Image:           "cloudflare/cloudflared:latest",
+			ImagePullPolicy: "IfNotPresent",
+			Replicas:        2,
+			Protocol:        "quic",
+			ExtraArgs:       []string{"--post-quantum"},
+		},
 		tokenSecretVersion: "42",
 		namespace:          "controller-system",
-		replicas:           2,
-		extraArgs:          []string{"--post-quantum"},
 	}.build()
 
 	assert.Equal(t, "controlled-cloudflared-connector", deployment.Name)
@@ -50,11 +50,12 @@ func TestControlledCloudflaredDeploymentBuild(t *testing.T) {
 }
 
 func TestControlledCloudflaredDeploymentBuildUsesConfiguredImage(t *testing.T) {
-	viper.Set("cloudflared-image", "cloudflare/cloudflared:2026.7.0")
-	viper.Set("cloudflared-image-pull-policy", "Always")
-	t.Cleanup(viper.Reset)
-
-	deployment := controlledCloudflaredDeployment{}.build()
+	deployment := controlledCloudflaredDeployment{
+		config: CloudflaredConfig{
+			Image:           "cloudflare/cloudflared:2026.7.0",
+			ImagePullPolicy: "Always",
+		},
+	}.build()
 	container := deployment.Spec.Template.Spec.Containers[0]
 
 	assert.Equal(t, "cloudflare/cloudflared:2026.7.0", container.Image)

--- a/test/integration/controller/controlled_cloudflared_connector_test.go
+++ b/test/integration/controller/controlled_cloudflared_connector_test.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"os"
 
 	cloudflarecontroller "github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/cloudflare-controller"
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/controller"
@@ -37,17 +36,15 @@ func (m *MockTunnelClient) FetchTunnelToken(ctx context.Context) (string, error)
 var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 	const testNamespace = "cloudflared-test"
 
-	BeforeEach(func() {
-		Expect(os.Setenv("CLOUDFLARED_REPLICA_COUNT", "2")).To(Succeed())
-		Expect(os.Setenv("CLOUDFLARED_IMAGE", "cloudflare/cloudflared:latest")).To(Succeed())
-		Expect(os.Setenv("CLOUDFLARED_IMAGE_PULL_POLICY", "IfNotPresent")).To(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(os.Unsetenv("CLOUDFLARED_REPLICA_COUNT")).To(Succeed())
-		Expect(os.Unsetenv("CLOUDFLARED_IMAGE")).To(Succeed())
-		Expect(os.Unsetenv("CLOUDFLARED_IMAGE_PULL_POLICY")).To(Succeed())
-	})
+	baseConfig := func() controller.CloudflaredConfig {
+		return controller.CloudflaredConfig{
+			Image:           "cloudflare/cloudflared:latest",
+			ImagePullPolicy: "IfNotPresent",
+			Replicas:        2,
+			Protocol:        "quic",
+			ExtraArgs:       []string{},
+		}
+	}
 
 	It("should return an error when fetching the tunnel token fails", func() {
 		mockTunnelClient := &MockTunnelClient{
@@ -56,7 +53,7 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 			},
 		}
 
-		err := controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, testNamespace, "quic", nil)
+		err := controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, testNamespace, baseConfig())
 
 		Expect(err).To(MatchError(ContainSubstring("fetch tunnel token")))
 	})
@@ -68,7 +65,7 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 			},
 		}
 
-		err := controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, "missing-namespace", "quic", nil)
+		err := controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, "missing-namespace", baseConfig())
 
 		Expect(err).To(MatchError(ContainSubstring("create or update tunnel token secret")))
 	})
@@ -90,10 +87,8 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 			},
 		}
 
-		protocol := "quic"
-
 		// Act
-		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, protocol, []string{})
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, baseConfig())
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert deployment
@@ -148,17 +143,16 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 			},
 		}
 
-		protocol := "quic"
-
 		// Create initial deployment
-		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, protocol, []string{})
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, baseConfig())
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(os.Setenv("CLOUDFLARED_REPLICA_COUNT", "3")).To(Succeed())
-		Expect(os.Setenv("CLOUDFLARED_IMAGE", "cloudflare/cloudflared:2022.3.0")).To(Succeed())
+		updatedConfig := baseConfig()
+		updatedConfig.Replicas = 3
+		updatedConfig.Image = "cloudflare/cloudflared:2022.3.0"
 
 		// Act
-		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, protocol, []string{})
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, updatedConfig)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert
@@ -190,11 +184,11 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 			},
 		}
 
-		protocol := "quic"
-		extraArgs := []string{"--post-quantum", "--edge-ip-version", "4"}
+		config := baseConfig()
+		config.ExtraArgs = []string{"--post-quantum", "--edge-ip-version", "4"}
 
 		// Act
-		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, protocol, extraArgs)
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, config)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert
@@ -229,10 +223,8 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 			},
 		}
 
-		protocol := "quic"
-
 		// Create initial deployment with first token
-		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, protocol, []string{})
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, baseConfig())
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify initial secret
@@ -257,7 +249,7 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 		currentToken = "updated-token"
 
 		// Act
-		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, protocol, []string{})
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, baseConfig())
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert secret was updated

--- a/test/integration/controller/suite_test.go
+++ b/test/integration/controller/suite_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -14,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 	"testing"
 )
 
@@ -33,10 +31,6 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// mirror the viper environment binding configured in main()
-	viper.AutomaticEnv()
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
 	rootLogger := stdr.NewWithOptions(log.New(os.Stderr, "", log.LstdFlags), stdr.Options{LogCaller: stdr.All})
 
 	logf.SetLogger(rootLogger)


### PR DESCRIPTION
## Problem

#292 introduced viper based configuration, but `dns-comment-template` was left out of the viper read path in `RunE`, so it is the only flag that cannot be set via environment variable. The cloudflared deployment defaults were also defined twice, once as `viper.SetDefault` in `main` and once as fallbacks next to the deployment builder. The flag to environment variable mapping was undocumented.

## Solution

Complete the viper wiring for the missing flag, keep defaults in a single place next to their usage, and document the configuration model in README.

## Major Changes

- `cmd/cloudflare-tunnel-ingress-controller/main.go`
  - read `dns-comment-template` through viper in `RunE`, consistent with every other flag
  - remove the duplicated `viper.SetDefault` calls for cloudflared image, pull policy and replica count, the fallbacks in `pkg/controller` are now the single source of defaults
- `README.md`
  - new Configuration section documenting precedence (flags > environment variables > defaults) and the full flag to environment variable table, including the cloudflared connector variables