### PR TITLE
feat: make cloudflared pod anti-affinity an explicit opt in

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The controller reads configuration from CLI flags and environment variables, wit
 | `--cloudflared-image` | `CLOUDFLARED_IMAGE` | `cloudflare/cloudflared:latest` |
 | `--cloudflared-image-pull-policy` | `CLOUDFLARED_IMAGE_PULL_POLICY` | `IfNotPresent` |
 | `--cloudflared-replica-count` | `CLOUDFLARED_REPLICA_COUNT` | `1` |
+| `--cloudflared-pod-anti-affinity` | `CLOUDFLARED_POD_ANTI_AFFINITY` | `false` |
 | `--cluster-domain` | `CLUSTER_DOMAIN` | `cluster.local` |
 | `--leader-elect` | `LEADER_ELECT` | `false` |
 | `--dns-comment-template` | `DNS_COMMENT_TEMPLATE` | `managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]` |

--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -39,6 +39,7 @@ type rootCmdFlags struct {
 	cloudflaredImage           string
 	cloudflaredImagePullPolicy string
 	cloudflaredReplicaCount    int32
+	cloudflaredPodAntiAffinity bool
 	clusterDomain              string
 	leaderElect                bool
 	dnsCommentTemplate         string
@@ -82,6 +83,7 @@ func main() {
 			options.cloudflaredImage = viper.GetString("cloudflared-image")
 			options.cloudflaredImagePullPolicy = viper.GetString("cloudflared-image-pull-policy")
 			options.cloudflaredReplicaCount = viper.GetInt32("cloudflared-replica-count")
+			options.cloudflaredPodAntiAffinity = viper.GetBool("cloudflared-pod-anti-affinity")
 			options.clusterDomain = viper.GetString("cluster-domain")
 			options.leaderElect = viper.GetBool("leader-elect")
 			options.dnsCommentTemplate = viper.GetString("dns-comment-template")
@@ -166,6 +168,7 @@ func main() {
 							Replicas:        options.cloudflaredReplicaCount,
 							Protocol:        options.cloudflaredProtocol,
 							ExtraArgs:       options.cloudflaredExtraArgs,
+							PodAntiAffinity: options.cloudflaredPodAntiAffinity,
 						})
 						if err != nil {
 							logger.WithName("controlled-cloudflared").Error(err, "create controlled cloudflared")
@@ -191,6 +194,7 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.cloudflaredImage, "cloudflared-image", options.cloudflaredImage, "container image for the managed cloudflared connector")
 	rootCommand.PersistentFlags().StringVar(&options.cloudflaredImagePullPolicy, "cloudflared-image-pull-policy", options.cloudflaredImagePullPolicy, "image pull policy for the managed cloudflared connector")
 	rootCommand.PersistentFlags().Int32Var(&options.cloudflaredReplicaCount, "cloudflared-replica-count", options.cloudflaredReplicaCount, "replica count for the managed cloudflared connector")
+	rootCommand.PersistentFlags().BoolVar(&options.cloudflaredPodAntiAffinity, "cloudflared-pod-anti-affinity", options.cloudflaredPodAntiAffinity, "spread cloudflared connector pods across nodes with required pod anti-affinity, replicas must not exceed the number of schedulable nodes")
 	rootCommand.PersistentFlags().StringVar(&options.clusterDomain, "cluster-domain", options.clusterDomain, "kubernetes cluster domain, used to build service FQDN (should match kubelet --cluster-domain)")
 	rootCommand.PersistentFlags().BoolVar(&options.leaderElect, "leader-elect", options.leaderElect, "enable leader election for high availability")
 	rootCommand.PersistentFlags().StringVar(&options.dnsCommentTemplate, "dns-comment-template", options.dnsCommentTemplate, "Go template for DNS record comments. Available variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}. Set to empty string to disable. Note: Cloudflare limits comment length by plan (Free: 100, Pro/Biz/Ent: 500 chars). See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/")

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
               value: {{ .Values.cloudflared.image.pullPolicy | quote }}
             - name: CLOUDFLARED_REPLICA_COUNT
               value: {{ .Values.cloudflared.replicaCount | quote }}
+            - name: CLOUDFLARED_POD_ANTI_AFFINITY
+              value: {{ .Values.cloudflared.podAntiAffinity | default false | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -103,6 +103,10 @@ cloudflared:
     tag: latest
   replicaCount: 1
   protocol: auto
+  # Spread cloudflared pods across nodes with required pod anti-affinity.
+  # When enabled, replicaCount must not exceed the number of schedulable nodes,
+  # otherwise the extra pods stay pending.
+  podAntiAffinity: false
   # Extra arguments to pass to cloudflared command
   # Example: ["--post-quantum", "--edge-ip-version", "4"]
   extraArgs: []

--- a/pkg/controller/controlled-cloudflared-connector.go
+++ b/pkg/controller/controlled-cloudflared-connector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -23,6 +24,7 @@ type CloudflaredConfig struct {
 	Replicas        int32
 	Protocol        string
 	ExtraArgs       []string
+	PodAntiAffinity bool
 }
 
 func CreateOrUpdateControlledCloudflared(
@@ -81,8 +83,8 @@ func CreateOrUpdateControlledCloudflared(
 			needsUpdate = true
 		}
 
-		desiredAffinity := buildPodAntiAffinity("controlled-cloudflared-connector", config.Replicas)
-		if !affinityEqual(existingDeployment.Spec.Template.Spec.Affinity, desiredAffinity) {
+		desiredAffinity := buildPodAntiAffinity("controlled-cloudflared-connector", config.PodAntiAffinity)
+		if !equality.Semantic.DeepEqual(existingDeployment.Spec.Template.Spec.Affinity, desiredAffinity) {
 			needsUpdate = true
 		}
 

--- a/pkg/controller/controlled-cloudflared-deployment.go
+++ b/pkg/controller/controlled-cloudflared-deployment.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"reflect"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +44,7 @@ func (d controlledCloudflaredDeployment) build() *appsv1.Deployment {
 					},
 				},
 				Spec: v1.PodSpec{
-					Affinity: buildPodAntiAffinity(appName, d.config.Replicas),
+					Affinity: buildPodAntiAffinity(appName, d.config.PodAntiAffinity),
 					Containers: []v1.Container{
 						{
 							Name:            appName,
@@ -75,10 +73,11 @@ func (d controlledCloudflaredDeployment) build() *appsv1.Deployment {
 	}
 }
 
-// buildPodAntiAffinity returns a pod anti-affinity that spreads pods across nodes.
-// Returns nil when replicas <= 1 (no point scheduling constraints for a single pod).
-func buildPodAntiAffinity(appName string, replicas int32) *v1.Affinity {
-	if replicas <= 1 {
+// buildPodAntiAffinity returns a pod anti-affinity that spreads pods across
+// nodes, or nil when the feature is disabled. The hard scheduling requirement
+// means replicas must not exceed the number of schedulable nodes.
+func buildPodAntiAffinity(appName string, enabled bool) *v1.Affinity {
+	if !enabled {
 		return nil
 	}
 	return &v1.Affinity{
@@ -95,15 +94,4 @@ func buildPodAntiAffinity(appName string, replicas int32) *v1.Affinity {
 			},
 		},
 	}
-}
-
-// affinityEqual compares two Affinity pointers for equality.
-func affinityEqual(a, b *v1.Affinity) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return reflect.DeepEqual(a, b)
 }

--- a/pkg/controller/controlled-cloudflared-deployment_test.go
+++ b/pkg/controller/controlled-cloudflared-deployment_test.go
@@ -50,17 +50,17 @@ func TestControlledCloudflaredDeploymentBuild(t *testing.T) {
 }
 
 func TestControlledCloudflaredDeploymentBuildAntiAffinity(t *testing.T) {
-	t.Run("single replica has no anti-affinity", func(t *testing.T) {
-		deployment := controlledCloudflaredDeployment{
-			config: CloudflaredConfig{Replicas: 1},
-		}.build()
-
-		assert.Nil(t, deployment.Spec.Template.Spec.Affinity, "single replica should have no affinity")
-	})
-
-	t.Run("multiple replicas have anti-affinity", func(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
 		deployment := controlledCloudflaredDeployment{
 			config: CloudflaredConfig{Replicas: 3},
+		}.build()
+
+		assert.Nil(t, deployment.Spec.Template.Spec.Affinity)
+	})
+
+	t.Run("enabled sets required anti-affinity", func(t *testing.T) {
+		deployment := controlledCloudflaredDeployment{
+			config: CloudflaredConfig{Replicas: 3, PodAntiAffinity: true},
 		}.build()
 
 		require.NotNil(t, deployment.Spec.Template.Spec.Affinity)
@@ -74,32 +74,18 @@ func TestControlledCloudflaredDeploymentBuildAntiAffinity(t *testing.T) {
 }
 
 func TestBuildPodAntiAffinity(t *testing.T) {
-	t.Run("nil for single replica", func(t *testing.T) {
-		assert.Nil(t, buildPodAntiAffinity("app", 1))
+	t.Run("nil when disabled", func(t *testing.T) {
+		assert.Nil(t, buildPodAntiAffinity("app", false))
 	})
 
-	t.Run("nil for zero replicas", func(t *testing.T) {
-		assert.Nil(t, buildPodAntiAffinity("app", 0))
-	})
-
-	t.Run("set for multiple replicas", func(t *testing.T) {
-		aff := buildPodAntiAffinity("my-app", 3)
+	t.Run("set when enabled", func(t *testing.T) {
+		aff := buildPodAntiAffinity("my-app", true)
 		require.NotNil(t, aff)
 		terms := aff.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 		require.Len(t, terms, 1)
 		assert.Equal(t, "kubernetes.io/hostname", terms[0].TopologyKey)
 		assert.Equal(t, map[string]string{"app": "my-app"}, terms[0].LabelSelector.MatchLabels)
 	})
-}
-
-func TestAffinityEqual(t *testing.T) {
-	aff1 := buildPodAntiAffinity("test", 2)
-	aff2 := buildPodAntiAffinity("test", 2)
-
-	assert.True(t, affinityEqual(nil, nil))
-	assert.False(t, affinityEqual(aff1, nil))
-	assert.False(t, affinityEqual(nil, aff1))
-	assert.True(t, affinityEqual(aff1, aff2))
 }
 
 func TestControlledCloudflaredDeploymentBuildUsesConfiguredImage(t *testing.T) {

--- a/test/integration/controller/controlled_cloudflared_connector_test.go
+++ b/test/integration/controller/controlled_cloudflared_connector_test.go
@@ -167,6 +167,61 @@ var _ = Describe("CreateOrUpdateControlledCloudflared", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("cloudflare/cloudflared:2022.3.0"))
 	})
 
+	It("should toggle pod anti-affinity on an existing deployment", func() {
+		// Prepare
+		namespaceFixtures := fixtures.NewKubernetesNamespaceFixtures(testNamespace, kubeClient)
+		ns, err := namespaceFixtures.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			err := namespaceFixtures.Stop(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+
+		mockTunnelClient := &MockTunnelClient{
+			FetchTunnelTokenFunc: func(ctx context.Context) (string, error) {
+				return "mock-token", nil
+			},
+		}
+
+		// Create initial deployment without anti-affinity
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, baseConfig())
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		err = kubeClient.Get(ctx, types.NamespacedName{
+			Namespace: ns,
+			Name:      "controlled-cloudflared-connector",
+		}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Affinity).To(BeNil())
+
+		// Enable anti-affinity
+		enabledConfig := baseConfig()
+		enabledConfig.PodAntiAffinity = true
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, enabledConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = kubeClient.Get(ctx, types.NamespacedName{
+			Namespace: ns,
+			Name:      "controlled-cloudflared-connector",
+		}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Affinity.PodAntiAffinity).NotTo(BeNil())
+
+		// Disable anti-affinity again
+		err = controller.CreateOrUpdateControlledCloudflared(ctx, kubeClient, mockTunnelClient, ns, baseConfig())
+		Expect(err).NotTo(HaveOccurred())
+
+		err = kubeClient.Get(ctx, types.NamespacedName{
+			Namespace: ns,
+			Name:      "controlled-cloudflared-connector",
+		}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Affinity).To(BeNil())
+	})
+
 	It("should include extra args in cloudflared command", func() {
 		// Prepare
 		namespaceFixtures := fixtures.NewKubernetesNamespaceFixtures(testNamespace, kubeClient)


### PR DESCRIPTION
## Problem

The anti-affinity from #325 switches on by itself whenever replicas exceed one, and it is a hard scheduling requirement. On clusters with fewer schedulable nodes than replicas this strands the extra pods as pending, so upgrading to the new version can silently degrade existing multi replica deployments. The hand rolled `affinityEqual` also duplicates what apimachinery already provides.

## Solution

Turn the anti-affinity into an explicit opt in, default off, exposed through flag, environment variable and helm value, and compare affinity with the community standard `equality.Semantic.DeepEqual`.

## Major Changes

- `pkg/controller`
  - `CloudflaredConfig` gains `PodAntiAffinity bool`, `buildPodAntiAffinity` keys off the toggle instead of the replica count
  - drift check uses `equality.Semantic.DeepEqual`, the hand rolled `affinityEqual` is removed
- `cmd/cloudflare-tunnel-ingress-controller`
  - new flag `--cloudflared-pod-anti-affinity`, default `false`, environment variable `CLOUDFLARED_POD_ANTI_AFFINITY`
- `helm/cloudflare-tunnel-ingress-controller`
  - new value `cloudflared.podAntiAffinity`, default `false`, injected as environment variable
- `test/integration`
  - new case toggling the option on and off and asserting the deployment follows