### PR TITLE
docs: cover recently merged features and fix helm install commands

### DIFF
--- a/docs/src/content/docs/guides/quickstart.md
+++ b/docs/src/content/docs/guides/quickstart.md
@@ -36,8 +36,8 @@ helm upgrade --install --wait \
   strrl.dev/cloudflare-tunnel-ingress-controller \
   --namespace cloudflare-tunnel-ingress-controller --create-namespace \
   --set cloudflare.apiToken="<CLOUDFLARE_API_TOKEN>" \
-         cloudflare.accountId="<CLOUDFLARE_ACCOUNT_ID>" \
-         cloudflare.tunnelName="<TUNNEL_NAME>"
+  --set cloudflare.accountId="<CLOUDFLARE_ACCOUNT_ID>" \
+  --set cloudflare.tunnelName="<TUNNEL_NAME>"
 ```
 
 Verify the controller pod and the bundled `cloudflared` connector are running:

--- a/docs/src/content/docs/reference/cloudflare-credentials.md
+++ b/docs/src/content/docs/reference/cloudflare-credentials.md
@@ -19,8 +19,8 @@ To let Helm create the secret, pass the values during installation:
 helm upgrade --install cloudflare-tunnel-ingress-controller \
   strrl.dev/cloudflare-tunnel-ingress-controller \
   --set cloudflare.apiToken="<CLOUDFLARE_API_TOKEN>" \
-         cloudflare.accountId="<CLOUDFLARE_ACCOUNT_ID>" \
-         cloudflare.tunnelName="<TUNNEL_NAME>"
+  --set cloudflare.accountId="<CLOUDFLARE_ACCOUNT_ID>" \
+  --set cloudflare.tunnelName="<TUNNEL_NAME>"
 ```
 
 ## Using an existing secret
@@ -62,4 +62,9 @@ cloudflare:
     apiTokenKey: api_token
 ```
 
-The controller only needs read access to these values. Rotating the secret in place automatically refreshes credentials on the next reconciliation loop.
+The controller only needs read access to these values. The chart injects them into the controller pod as environment variables, and the controller reads them once at startup, so rotating the secret in place does not refresh a running controller. After updating the secret, restart the controller to pick up the new credentials:
+
+```bash
+kubectl rollout restart deployment cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller
+```

--- a/docs/src/content/docs/reference/controller-configuration.md
+++ b/docs/src/content/docs/reference/controller-configuration.md
@@ -1,0 +1,35 @@
+---
+title: Controller Configuration
+description: Configure the controller through CLI flags or environment variables.
+---
+
+The controller reads its configuration from CLI flags. Every flag can also be supplied as an environment variable: uppercase the flag name and replace hyphens with underscores. When both are set, the CLI flag takes precedence.
+
+```bash
+# These are equivalent:
+--cloudflare-api-token=xxx
+CLOUDFLARE_API_TOKEN=xxx
+```
+
+The Helm chart wires the credential secret and chart values into these settings for you, so most Helm users never touch them directly. They are useful when running the controller outside Helm or when injecting configuration from an external secret manager.
+
+## Available settings
+
+| Flag                             | Environment variable           | Purpose                                                                                     |
+| -------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------- |
+| `--cloudflare-api-token`         | `CLOUDFLARE_API_TOKEN`         | Cloudflare API token, see [Cloudflare Credentials](/reference/cloudflare-credentials/).     |
+| `--cloudflare-account-id`        | `CLOUDFLARE_ACCOUNT_ID`        | Account identifier that owns the tunnel.                                                    |
+| `--cloudflare-tunnel-name`       | `CLOUDFLARE_TUNNEL_NAME`       | Tunnel name created or reused by the controller.                                            |
+| `--ingress-class`                | `INGRESS_CLASS`                | Ingress class to watch, defaults to `cloudflare-tunnel`.                                    |
+| `--controller-class`             | `CONTROLLER_CLASS`             | Controller class name, defaults to `strrl.dev/cloudflare-tunnel-ingress-controller`.        |
+| `--namespace`                    | `NAMESPACE`                    | Namespace where the managed cloudflared connector runs.                                     |
+| `--cloudflared-protocol`         | `CLOUDFLARED_PROTOCOL`         | Transport protocol for cloudflared, defaults to `auto`.                                     |
+| `--cloudflared-extra-args`       | `CLOUDFLARED_EXTRA_ARGS`       | Extra arguments passed to the cloudflared command.                                          |
+| `--cloudflared-image`            | `CLOUDFLARED_IMAGE`            | Container image for the managed cloudflared connector.                                      |
+| `--cloudflared-image-pull-policy`| `CLOUDFLARED_IMAGE_PULL_POLICY`| Image pull policy for the connector pods.                                                   |
+| `--cloudflared-replica-count`    | `CLOUDFLARED_REPLICA_COUNT`    | Number of cloudflared connector pods.                                                       |
+| `--cloudflared-deployment-config`| `CLOUDFLARED_DEPLOYMENT_CONFIG`| Path to a JSON file with pod template customization for the connector Deployment.           |
+| `--cluster-domain`               | `CLUSTER_DOMAIN`               | Kubernetes cluster domain used to build Service FQDNs, defaults to `cluster.local`.         |
+| `--leader-elect`                 | `LEADER_ELECT`                 | Enable leader election when running more than one controller replica.                       |
+| `--dns-comment-template`         | `DNS_COMMENT_TEMPLATE`         | Go template for DNS record comments, empty string disables comments.                        |
+| `--log-level`                    | `LOG_LEVEL`                    | Numeric log verbosity.                                                                      |

--- a/docs/src/content/docs/reference/helm-values.md
+++ b/docs/src/content/docs/reference/helm-values.md
@@ -16,6 +16,8 @@ For the complete and up-to-date list of all available Helm values, refer to the 
 | `ingressClass.name`                | `cloudflare-tunnel`                 | Rename if you run multiple controllers in one cluster.                          |
 | `ingressClass.isDefaultClass`      | `false`                             | Set to `true` only if Cloudflare Tunnel should handle every ingress by default. |
 | `cloudflared.image.tag`            | `latest`                            | Pin to a specific cloudflared version for reproducible environments.            |
+| `cloudflared.replicaCount`         | `1`                                 | Number of cloudflared connector pods maintaining the tunnel.                    |
+| `cloudflared.podAntiAffinity`      | `false`                             | Spread connector pods across nodes with a required anti-affinity. Needs at least as many schedulable nodes as replicas, otherwise the extra pods stay pending. Ignored when `cloudflared.affinity` is set. |
 | `cloudflared.extraArgs`            | `[]`                                | Append extra arguments such as `--post-quantum`.                                |
 | `cloudflaredServiceMonitor.create` | `false`                             | Enable when you scrape metrics with Prometheus Operator.                        |
 | `replicaCount`                     | `1`                                 | Scale the controller deployment (enable leader election for >1).                |

--- a/docs/src/content/docs/reference/ingress-annotations.md
+++ b/docs/src/content/docs/reference/ingress-annotations.md
@@ -5,12 +5,13 @@ description: Fine-tune Cloudflare Tunnel behaviour with controller-specific anno
 
 Annotations let you customise how the controller configures Cloudflare for each ingress rule. Apply them on the ingress metadata alongside the `cloudflare-tunnel` class.
 
-| Annotation                                                          | Purpose                                                                            |
-| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol`   | Override the upstream protocol (`http` default, `https` supported).                |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify`   | Enable (`on`) or disable (`off`) TLS verification when proxying to HTTPS backends. |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`   | Rewrite the HTTP Host header sent to the backend Service.                          |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name` | Set the SNI hostname when terminating TLS to the origin.                           |
+| Annotation                                                              | Purpose                                                                                                |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol`       | Protocol used to reach the backend Service (`http` default). Any protocol supported by cloudflared works, including `https`, `tcp`, `ssh`, and `rdp`. |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify`       | Enable (`on`) or disable (`off`) TLS verification when proxying to HTTPS backends.                     |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`       | Rewrite the HTTP Host header sent to the backend Service.                                              |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`     | Set the SNI hostname when terminating TLS to the origin.                                               |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management` | Set to `"true"` to stop the controller from managing Cloudflare DNS records for this ingress while still configuring the tunnel route. |
 
 Example ingress snippet:
 
@@ -26,4 +27,20 @@ metadata:
     cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name: dash.internal.svc
 ```
 
-The controller emits Kubernetes events and logs when an annotation is invalid or conflicts with connector capabilities. Tail controller logs to confirm annotated rules reconcile successfully.
+## Non HTTP backend protocols
+
+Set `backend-protocol` to `tcp`, `ssh`, `rdp`, or any other protocol cloudflared supports to expose non HTTP services. The Kubernetes Ingress spec still requires an `http.paths` entry for such rules, but the controller drops the path from the resulting tunnel rule because path based routing only exists for HTTP(S). Use `/` as a placeholder path.
+
+## Disabling DNS management
+
+Set `disable-dns-management: "true"` when DNS for a hostname is delegated to another system, for example external-dns or a Cloudflare Load Balancer in front of the tunnel. The controller keeps reconciling the tunnel ingress rule but no longer creates or updates the CNAME and ownership TXT records, and it stops erroring when the hostname belongs to no managed zone.
+
+If the controller previously managed DNS for the hostname, enabling the annotation makes it relinquish ownership instead of just going hands off:
+
+- The ownership TXT record it created is deleted.
+- Its CNAME record is deleted only while it still points at this tunnel. A CNAME already repointed by an external system is left untouched.
+- Records owned by a different tunnel are never touched.
+
+## Validation feedback
+
+The controller emits Kubernetes Warning events on the Ingress object when a rule is invalid or cannot be applied, visible via `kubectl describe ingress`. See [troubleshooting with events](/reference/ingress/#troubleshooting-with-events) for the event reasons and their meaning.

--- a/docs/src/content/docs/reference/ingress.md
+++ b/docs/src/content/docs/reference/ingress.md
@@ -44,3 +44,25 @@ spec:
 ```
 
 Consult the [ingress annotations reference](/reference/ingress-annotations/) for advanced routing behaviour such as protocol overrides, TLS verification settings, and host header rewrites.
+
+## Wildcard hostnames
+
+Hosts may use a leading wildcard label such as `*.example.com`. The controller creates the matching wildcard DNS record and orders the tunnel rules so that routing behaves as you would expect:
+
+- An exact hostname always wins over a wildcard. With rules for `app.example.com` and `*.example.com`, requests to `app.example.com` reach the exact rule and any other subdomain falls back to the wildcard.
+- A more specific wildcard wins over a broader one. `*.internal.example.com` is matched before `*.example.com`.
+- For the same hostname, rules with longer paths are matched first.
+
+The order of rules inside your Ingress spec does not matter. The controller sorts them deterministically before writing the tunnel configuration.
+
+## Troubleshooting with events
+
+The Ingress API has no status conditions, so the controller reports problems as Warning events on the Ingress object. Check them with `kubectl describe ingress <name>`:
+
+| Reason            | Meaning                                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `RuleSkipped`     | A rule carries only a host and no `http` section, so it cannot be turned into a tunnel route.                    |
+| `TLSIgnored`      | The ingress has a `tls` section. SSL passthrough is not supported, Cloudflare terminates TLS at the edge.        |
+| `TransformFailed` | A rule could not be transformed, for example a headless Service, a missing Service, or an unsupported `pathType`. |
+
+Rules that fail to transform are skipped while the remaining rules still reconcile, so a single broken rule does not take down the other routes of the ingress.


### PR DESCRIPTION
## Problem

The docs site imported in #331 shipped with two review comments unaddressed (broken multi value `--set` install commands, and a wrong claim that in place secret rotation refreshes credentials). It also predates several recently merged user facing features, so they are not documented anywhere on the site.

## Solution

Fix the install commands and the rotation guidance, and document every user facing change merged recently.

## Major Changes

- quickstart and cloudflare credentials
  - each helm value now passed through its own `--set` flag, previously only the first line was consumed and the install failed
  - credential rotation section now explains that values are injected as env vars read once at startup, with a `kubectl rollout restart` step
- ingress annotations reference
  - new `disable-dns-management` annotation with its ownership relinquish behavior (#311, #323)
  - `backend-protocol` updated to cover non HTTP protocols, plus a section on path handling for `tcp`/`ssh`/`rdp` (#321)
- ingress reference
  - wildcard hostname support and rule ordering semantics (#287, #322)
  - troubleshooting section for the `RuleSkipped` / `TLSIgnored` / `TransformFailed` warning events (#317)
- helm values reference
  - `cloudflared.replicaCount` and `cloudflared.podAntiAffinity` with the scheduling caveat (#325, #326)
- new controller configuration reference page
  - flag to environment variable mapping introduced by the viper migration, full settings table (#292, #324)