### PR TITLE
ci: skip e2e test for docs-only changes

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches:
       - "master"
+    paths-ignore:
+      - "docs/**"
 
 permissions: read-all
 


### PR DESCRIPTION
## Problem

The e2e test runs on every pull request, including docs-only changes. E2e runs share a single Cloudflare tunnel and are strictly serialized, so docs PRs waste a slow, contended CI slot for no benefit.

## Solution

Add \`paths-ignore: docs/**\` to the e2e workflow's \`pull_request\` trigger so PRs touching only \`docs/\` skip the e2e test.

## Major Changes

- .github/workflows/e2e-test.yaml
  - \`pull_request\` trigger now ignores changes under \`docs/\`; previously e2e ran on every PR targeting master