### PR TITLE
docs: slim README down to point at the docs site, purify quickstart into a tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We'd love to hear how the project works for you—please take a minute to fill o
 
 ## Prerequisites
 
-To use the Cloudflare Tunnel Ingress Controller, you need to have a Cloudflare account and a domain configured on Cloudflare. You also need a Cloudflare API token with `Zone:Zone:Read`, `Zone:DNS:Edit`, and `Account:Cloudflare Tunnel:Edit` permissions, as described in [Cloudflare credentials](https://tunnel.strrl.dev/reference/cloudflare-credentials/).
+To use the Cloudflare Tunnel Ingress Controller, you need to have a Cloudflare account and a domain configured on Cloudflare. You also need a Cloudflare API token with `Zone:Zone:Read`, `Zone:DNS:Edit`, and `Account:Cloudflare Tunnel:Edit` permissions, which you can create quickly using [this template](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22edit%22%7D%2C%7B%22key%22%3A%22argotunnel%22%2C%22type%22%3A%22edit%22%7D%5D&name=Cloudflare%20Tunnel%20Ingress%20Controller&accountId=*&zoneId=all); see [Cloudflare credentials](https://tunnel.strrl.dev/reference/cloudflare-credentials/) for details.
 
 Additionally, you need to fetch the Account ID from the Cloudflare dashboard.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We'd love to hear how the project works for you—please take a minute to fill o
 
 ## Prerequisites
 
-To use the Cloudflare Tunnel Ingress Controller, you need to have a Cloudflare account and a domain configured on Cloudflare. You also need to create a Cloudflare API token with the following permissions: `Zone:Zone:Read`, `Zone:DNS:Edit`, and `Account:Cloudflare Tunnel:Edit`.
+To use the Cloudflare Tunnel Ingress Controller, you need to have a Cloudflare account and a domain configured on Cloudflare. You also need a Cloudflare API token with `Zone:Zone:Read`, `Zone:DNS:Edit`, and `Account:Cloudflare Tunnel:Edit` permissions, as described in [Cloudflare credentials](https://tunnel.strrl.dev/reference/cloudflare-credentials/).
 
 Additionally, you need to fetch the Account ID from the Cloudflare dashboard.
 
@@ -14,96 +14,25 @@ Finally, you need to have a Kubernetes cluster with public Internet access.
 
 ## Get Started
 
-Take a look on this video to see how smoothly and easily it works:
-
-[![Less than 4 minutes! Bootstrap a Kubernetes Cluster and Expose Kubernetes Dashboard to the Internet.](https://markdown-videos.vercel.app/youtube/e-ARlEnS4zQ)](http://www.youtube.com/watch?v=e-ARlEnS4zQ "Less than 4 minutes! Bootstrap a Kubernetes Cluster and Expose Kubernetes Dashboard to the Internet.")
-
-Want to DIY? The following instructions would help your bootstrap a minikube Kubernetes Cluster, then expose the Kubernetes Dashboard to the internet via Cloudflare Tunnel Ingress Controller.
-
-- Step 0: You should have a Cloudflare account and a domain configured on Cloudflare.
-- Step 1: Create a Cloudflare API token with the following:
-  - `Zone:Zone:Read`
-  - `Zone:DNS:Edit`
-  - `Account:Cloudflare Tunnel:Edit`
-
-You can copy the following template URL to create the API token with the required permissions directly:
-
-```text
-https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=[{"key":"zone","type":"read"},{"key":"dns","type":"edit"},{"key":"argotunnel","type":"edit"}]&name=Cloudflare%20Tunnel%20Ingress%20Controller&accountId=*&zoneId=all
-```
-
-- Step 2: Fetch the Account ID from the Cloudflare dashboard, follow the instructions from [this cloudflare developer doc](https://developers.cloudflare.com/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
-- Step 3: Bootstrap a minikube cluster
-
-```bash
-minikube start
-```
-
-- Add Helm Repository;
-
-```bash
-helm repo add strrl.dev https://helm.strrl.dev
-helm repo update
-```
-
-- Step 4: Install cloudflare-tunnel-ingress-controller with Helm:
+Install the controller with Helm:
 
 ```bash
 helm upgrade --install --wait \
-  -n cloudflare-tunnel-ingress-controller --create-namespace \
   cloudflare-tunnel-ingress-controller \
-  strrl.dev/cloudflare-tunnel-ingress-controller \
-  --set=cloudflare.apiToken="<cloudflare-api-token>",cloudflare.accountId="<cloudflare-account-id>",cloudflare.tunnelName="<your-favorite-tunnel-name>" 
+  cloudflare-tunnel-ingress-controller \
+  --repo https://helm.strrl.dev \
+  --namespace cloudflare-tunnel-ingress-controller \
+  --create-namespace \
+  --set cloudflare.apiToken="<CLOUDFLARE_API_TOKEN>" \
+  --set cloudflare.accountId="<CLOUDFLARE_ACCOUNT_ID>" \
+  --set cloudflare.tunnelName="<TUNNEL_NAME>"
 ```
 
-> if the tunnel does not exist, controller will create it for you.
-
-- Step 5: Then enable some awesome features in minikube, like kubernetes-dashboard:
-
-```bash
-minikube addons enable dashboard
-minikube addons enable metrics-server
-```
-
-- Then expose the dashboard to the internet by creating an `Ingress`:
-
-```bash
-kubectl -n kubernetes-dashboard \
-  create ingress dashboard-via-cf-tunnel \
-  --rule="<your-favorite-domain>/*=kubernetes-dashboard:80"\
-  --class cloudflare-tunnel
-```
-
-> for example, I would use `dash.strrl.cloud` as my favorite domain here.
-
-- Step 6: At last, access the dashboard via the domain you just created:
-
-![dash.strrl.cloud](./static/dash.strrl.cloud.png)
-
-- Done! Enjoy! 🎉
+Follow the [quickstart](https://tunnel.strrl.dev/guides/quickstart/) to publish your first Ingress.
 
 ## Configuration
 
-The controller reads configuration from CLI flags and environment variables, with precedence: CLI flags > environment variables > built in defaults. Every flag maps to an environment variable by uppercasing the flag name and replacing `-` with `_`. This is handy for local debugging with an `.env` file, since flags and environment variables share a single config loading path.
-
-| Flag | Environment variable | Default |
-| --- | --- | --- |
-| `--cloudflare-api-token` | `CLOUDFLARE_API_TOKEN` | (required) |
-| `--cloudflare-account-id` | `CLOUDFLARE_ACCOUNT_ID` | (required) |
-| `--cloudflare-tunnel-name` | `CLOUDFLARE_TUNNEL_NAME` | (required) |
-| `--ingress-class` | `INGRESS_CLASS` | `cloudflare-tunnel` |
-| `--controller-class` | `CONTROLLER_CLASS` | `strrl.dev/cloudflare-tunnel-ingress-controller` |
-| `--log-level` | `LOG_LEVEL` | `0` |
-| `--namespace` | `NAMESPACE` | `default` |
-| `--cloudflared-protocol` | `CLOUDFLARED_PROTOCOL` | `auto` |
-| `--cloudflared-extra-args` | `CLOUDFLARED_EXTRA_ARGS` | (empty) |
-| `--cloudflared-image` | `CLOUDFLARED_IMAGE` | `cloudflare/cloudflared:latest` |
-| `--cloudflared-image-pull-policy` | `CLOUDFLARED_IMAGE_PULL_POLICY` | `IfNotPresent` |
-| `--cloudflared-replica-count` | `CLOUDFLARED_REPLICA_COUNT` | `1` |
-| `--cloudflared-deployment-config` | `CLOUDFLARED_DEPLOYMENT_CONFIG` | (empty) |
-| `--cluster-domain` | `CLUSTER_DOMAIN` | `cluster.local` |
-| `--leader-elect` | `LEADER_ELECT` | `false` |
-| `--dns-comment-template` | `DNS_COMMENT_TEMPLATE` | `managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]` |
+The controller supports CLI flags and matching environment variables. See [controller configuration](https://tunnel.strrl.dev/reference/controller-configuration/) for the complete list and defaults.
 
 ## Alternative
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Finally, you need to have a Kubernetes cluster with public Internet access.
 
 ## Get Started
 
+Take a look on this video to see how smoothly and easily it works:
+
+[![Less than 4 minutes! Bootstrap a Kubernetes Cluster and Expose Kubernetes Dashboard to the Internet.](https://markdown-videos.vercel.app/youtube/e-ARlEnS4zQ)](http://www.youtube.com/watch?v=e-ARlEnS4zQ "Less than 4 minutes! Bootstrap a Kubernetes Cluster and Expose Kubernetes Dashboard to the Internet.")
+
 Install the controller with Helm:
 
 ```bash

--- a/docs/src/content/docs/guides/quickstart.md
+++ b/docs/src/content/docs/guides/quickstart.md
@@ -10,7 +10,7 @@ Use this guide to install the controller with Helm and publish a Kubernetes Serv
 - A Kubernetes cluster running version 1.26 or later with cluster-admin access.
 - `kubectl` and `helm` configured for the cluster.
 - A Cloudflare account with an active zone and Argo Tunnel access enabled.
-- A Cloudflare API token with `Account.Cloudflare Tunnel:Edit`, `Zone.DNS:Edit`, and `Zone.Zone:Read` permissions, created by following [Cloudflare credentials](/reference/cloudflare-credentials/).
+- A Cloudflare API token with `Account.Cloudflare Tunnel:Edit`, `Zone.DNS:Edit`, and `Zone.Zone:Read` permissions. Create it quickly using [this template](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22edit%22%7D%2C%7B%22key%22%3A%22argotunnel%22%2C%22type%22%3A%22edit%22%7D%5D&name=Cloudflare%20Tunnel%20Ingress%20Controller&accountId=*&zoneId=all), or see [Cloudflare credentials](/reference/cloudflare-credentials/) for details.
 - Your Cloudflare account ID.
 - A Service named `kubernetes-dashboard` in the `kubernetes-dashboard` namespace.
 

--- a/docs/src/content/docs/guides/quickstart.md
+++ b/docs/src/content/docs/guides/quickstart.md
@@ -10,45 +10,29 @@ Use this guide to install the controller with Helm and publish a Kubernetes Serv
 - A Kubernetes cluster running version 1.26 or later with cluster-admin access.
 - `kubectl` and `helm` configured for the cluster.
 - A Cloudflare account with an active zone and Argo Tunnel access enabled.
-- An API token that can manage tunnels and DNS:
-  - `Account.Cloudflare Tunnel:Edit`
-  - `Zone.DNS:Edit`
-  - `Zone.Zone:Read`
-- You can create API Key and prefill the permissions with [this template](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22edit%22%7D%2C%7B%22key%22%3A%22argotunnel%22%2C%22type%22%3A%22edit%22%7D%5D&name=Cloudflare%20Tunnel%20Ingress%20Controller&accountId=*&zoneId=all).
-- Your Cloudflare account ID. Follow the official guide to [find your account and zone IDs](https://developers.cloudflare.com/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/).
+- A Cloudflare API token with `Account.Cloudflare Tunnel:Edit`, `Zone.DNS:Edit`, and `Zone.Zone:Read` permissions, created by following [Cloudflare credentials](/reference/cloudflare-credentials/).
+- Your Cloudflare account ID.
+- A Service named `kubernetes-dashboard` in the `kubernetes-dashboard` namespace.
 
-## 1. Add the Helm repository
+## 1. Install the controller
 
-Add the official chart and refresh your local index:
-
-```bash
-helm repo add strrl.dev https://helm.strrl.dev
-helm repo update
-```
-
-## 2. Install the controller
-
-Install (or upgrade) the controller. Replace the placeholders with your API token, account ID, and preferred tunnel name. The chart provisions the `cloudflare-api` secret automatically using these values.
+Replace the placeholders with your API token, account ID, and preferred tunnel name. Helm installs the controller and creates its credential Secret.
 
 ```bash
 helm upgrade --install --wait \
   cloudflare-tunnel-ingress-controller \
-  strrl.dev/cloudflare-tunnel-ingress-controller \
-  --namespace cloudflare-tunnel-ingress-controller --create-namespace \
+  cloudflare-tunnel-ingress-controller \
+  --repo https://helm.strrl.dev \
+  --namespace cloudflare-tunnel-ingress-controller \
+  --create-namespace \
   --set cloudflare.apiToken="<CLOUDFLARE_API_TOKEN>" \
   --set cloudflare.accountId="<CLOUDFLARE_ACCOUNT_ID>" \
   --set cloudflare.tunnelName="<TUNNEL_NAME>"
 ```
 
-Verify the controller pod and the bundled `cloudflared` connector are running:
+## 2. Create your first Ingress
 
-```bash
-kubectl get pods -n cloudflare-tunnel-ingress-controller
-```
-
-## 3. Publish a Service with Ingress
-
-Create an `Ingress` that targets your Service and assigns the `cloudflare-tunnel` ingress class. The controller watches for these routes and configures Cloudflare automatically.
+Save the following manifest as `dashboard-ingress.yaml`. Replace `dash.example.com` with a hostname in your Cloudflare zone.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -59,7 +43,7 @@ metadata:
 spec:
   ingressClassName: cloudflare-tunnel
   rules:
-    - host: dash.example.com # <- REPLACE ME!
+    - host: dash.example.com
       http:
         paths:
           - path: /
@@ -71,20 +55,14 @@ spec:
                   number: 80
 ```
 
-Apply the manifest and monitor the ingress status until a Cloudflare hostname appears:
+Apply the manifest:
 
 ```bash
 kubectl apply -f dashboard-ingress.yaml
-kubectl get ingress dashboard -n kubernetes-dashboard -o yaml
 ```
 
-## 4. Validate externally
+## 3. Verify the Ingress
 
-- Visit `https://dash.example.com` (or your chosen hostname) to confirm the proxied application is reachable.
-- Run `kubectl logs deployment/cloudflare-tunnel-ingress-controller -n cloudflare-tunnel-ingress-controller` to troubleshoot tunnel or DNS issues.
+Open `https://dash.example.com`, using the hostname you chose. The Kubernetes Dashboard should load through Cloudflare Tunnel.
 
-## Next steps
-
-- Review the reference docs for the [ingress class](/reference/ingress-class/), [credentials](/reference/cloudflare-credentials/), [ingress](/reference/ingress/), and [ingress annotations](/reference/ingress-annotations/).
-- Switch the chart to an existing secret if you prefer to manage credentials outside Helm releases.
-- Automate deployment via GitOps and monitor the `cloudflared` connector pods for long-lived tunnels.
+If something goes wrong, see [troubleshooting](/guides/troubleshooting/).


### PR DESCRIPTION
## Problem

The README and the docs site maintain three hand-written copies of the same content (install steps, full flag table, API token permissions), which is a drift risk. The quickstart also mixes how-to and reference content (API token creation details, debugging tips) into what should be a linear tutorial.

Part of #334.

## Solution

Slim the README down to point at the docs site as the single source of truth, and purify the quickstart into a pure Divio tutorial with one linear zero-to-first-Ingress path.

## Major Changes

- `README.md`
  - Full 16-flag table replaced with a link to the controller-configuration reference (the Default column is merged into that page in the reference-gaps PR; merge that one first).
  - 6-step minikube walkthrough replaced with the shortest working helm install command plus a quickstart link.
  - API token permission details replaced with the three required scopes plus a link to the cloudflare-credentials reference.
- `docs/src/content/docs/guides/quickstart.md`
  - Token creation details moved out in favor of a link to the credentials reference.
  - Keeps a single linear path: install, provide credentials, create the dashboard Ingress, verify.
  - Debugging tips removed; ends with a link to /guides/troubleshooting/ (created in the troubleshooting PR).

Merge order note: best merged after the reference-gaps PR (flag defaults) and the troubleshooting PR (target of the new link).

Docs were written by Codex (gpt-5.6-sol) and reviewed by a separate review agent.