### PR TITLE
docs: fill reference gaps in controller configuration and helm values

### DIFF
--- a/docs/src/content/docs/reference/controller-configuration.md
+++ b/docs/src/content/docs/reference/controller-configuration.md
@@ -3,7 +3,7 @@ title: Controller Configuration
 description: Configure the controller through CLI flags or environment variables.
 ---
 
-The controller reads its configuration from CLI flags. Every flag can also be supplied as an environment variable: uppercase the flag name and replace hyphens with underscores. When both are set, the CLI flag takes precedence.
+The controller reads its configuration from CLI flags. Every flag can also be supplied as an environment variable: uppercase the flag name and replace hyphens with underscores. When both are set, the CLI flag takes precedence. The table below lists every supported controller flag.
 
 ```bash
 # These are equivalent:
@@ -15,21 +15,21 @@ The Helm chart wires the credential secret and chart values into these settings 
 
 ## Available settings
 
-| Flag                             | Environment variable           | Purpose                                                                                     |
-| -------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------- |
-| `--cloudflare-api-token`         | `CLOUDFLARE_API_TOKEN`         | Cloudflare API token, see [Cloudflare Credentials](/reference/cloudflare-credentials/).     |
-| `--cloudflare-account-id`        | `CLOUDFLARE_ACCOUNT_ID`        | Account identifier that owns the tunnel.                                                    |
-| `--cloudflare-tunnel-name`       | `CLOUDFLARE_TUNNEL_NAME`       | Tunnel name created or reused by the controller.                                            |
-| `--ingress-class`                | `INGRESS_CLASS`                | Ingress class to watch, defaults to `cloudflare-tunnel`.                                    |
-| `--controller-class`             | `CONTROLLER_CLASS`             | Controller class name, defaults to `strrl.dev/cloudflare-tunnel-ingress-controller`.        |
-| `--namespace`                    | `NAMESPACE`                    | Namespace where the managed cloudflared connector runs.                                     |
-| `--cloudflared-protocol`         | `CLOUDFLARED_PROTOCOL`         | Transport protocol for cloudflared, defaults to `auto`.                                     |
-| `--cloudflared-extra-args`       | `CLOUDFLARED_EXTRA_ARGS`       | Extra arguments passed to the cloudflared command.                                          |
-| `--cloudflared-image`            | `CLOUDFLARED_IMAGE`            | Container image for the managed cloudflared connector.                                      |
-| `--cloudflared-image-pull-policy`| `CLOUDFLARED_IMAGE_PULL_POLICY`| Image pull policy for the connector pods.                                                   |
-| `--cloudflared-replica-count`    | `CLOUDFLARED_REPLICA_COUNT`    | Number of cloudflared connector pods.                                                       |
-| `--cloudflared-deployment-config`| `CLOUDFLARED_DEPLOYMENT_CONFIG`| Path to a JSON file with pod template customization for the connector Deployment.           |
-| `--cluster-domain`               | `CLUSTER_DOMAIN`               | Kubernetes cluster domain used to build Service FQDNs, defaults to `cluster.local`.         |
-| `--leader-elect`                 | `LEADER_ELECT`                 | Enable leader election when running more than one controller replica.                       |
-| `--dns-comment-template`         | `DNS_COMMENT_TEMPLATE`         | Go template for DNS record comments, empty string disables comments.                        |
-| `--log-level`                    | `LOG_LEVEL`                    | Numeric log verbosity.                                                                      |
+| Flag                              | Environment variable            | Default                                                                     | Description                                                                                                                                                          |
+| --------------------------------- | ------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--cloudflare-api-token`          | `CLOUDFLARE_API_TOKEN`          | (required)                                                                  | Cloudflare API token. See [Cloudflare Credentials](/reference/cloudflare-credentials/).                                                                              |
+| `--cloudflare-account-id`         | `CLOUDFLARE_ACCOUNT_ID`         | (required)                                                                  | Account identifier that owns the tunnel.                                                                                                                             |
+| `--cloudflare-tunnel-name`        | `CLOUDFLARE_TUNNEL_NAME`        | (required)                                                                  | Tunnel name created or reused by the controller.                                                                                                                     |
+| `--ingress-class`                 | `INGRESS_CLASS`                 | `cloudflare-tunnel`                                                         | Ingress class name watched by the controller.                                                                                                                        |
+| `--controller-class`              | `CONTROLLER_CLASS`              | `strrl.dev/cloudflare-tunnel-ingress-controller`                            | Controller class name used in `IngressClass.spec.controller`.                                                                                                        |
+| `--log-level`, `-v`               | `LOG_LEVEL`                     | `0`                                                                         | Numeric log verbosity. `-v` is the shorthand for `--log-level` and accepts the same integer value.                                                                   |
+| `--namespace`                     | `NAMESPACE`                     | `default`                                                                   | Namespace where the managed cloudflared connector runs.                                                                                                              |
+| `--cloudflared-protocol`          | `CLOUDFLARED_PROTOCOL`          | `auto`                                                                      | Transport protocol used by cloudflared.                                                                                                                              |
+| `--cloudflared-extra-args`        | `CLOUDFLARED_EXTRA_ARGS`        | (empty)                                                                     | Extra arguments passed to the cloudflared command.                                                                                                                   |
+| `--cloudflared-image`             | `CLOUDFLARED_IMAGE`             | `cloudflare/cloudflared:latest`                                             | Container image for the managed cloudflared connector.                                                                                                               |
+| `--cloudflared-image-pull-policy` | `CLOUDFLARED_IMAGE_PULL_POLICY` | `IfNotPresent`                                                              | Image pull policy for the managed connector pods.                                                                                                                    |
+| `--cloudflared-replica-count`     | `CLOUDFLARED_REPLICA_COUNT`     | `1`                                                                         | Number of managed cloudflared connector pods.                                                                                                                        |
+| `--cloudflared-deployment-config` | `CLOUDFLARED_DEPLOYMENT_CONFIG` | (empty)                                                                     | Path to a JSON file with pod template customization for the managed connector Deployment.                                                                            |
+| `--cluster-domain`                | `CLUSTER_DOMAIN`                | `cluster.local`                                                             | Kubernetes cluster domain used to build Service FQDNs.                                                                                                               |
+| `--leader-elect`                  | `LEADER_ELECT`                  | `false`                                                                     | Enable leader election for high availability.                                                                                                                        |
+| `--dns-comment-template`          | `DNS_COMMENT_TEMPLATE`          | `managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]` | Go template for DNS record comments. Set it to an empty string to disable comments. Available variables are `{{.TunnelName}}`, `{{.TunnelId}}`, and `{{.Hostname}}`. |

--- a/docs/src/content/docs/reference/helm-values.md
+++ b/docs/src/content/docs/reference/helm-values.md
@@ -3,24 +3,69 @@ title: Helm Values
 description: Tune the controller and cloudflared connectors with chart values.
 ---
 
-The `strrl.dev/cloudflare-tunnel-ingress-controller` chart exposes values for production hardening, observability, and connector behaviour. This table highlights the most frequently adjusted settings.
+The `strrl.dev/cloudflare-tunnel-ingress-controller` chart exposes values for production hardening, observability, and connector behaviour. The tables below cover common settings and pod customization.
 
 For the complete and up-to-date list of all available Helm values, refer to the [values.yaml](https://github.com/STRRL/cloudflare-tunnel-ingress-controller/blob/master/helm/cloudflare-tunnel-ingress-controller/values.yaml) file in the repository.
 
-| Value                              | Default                             | Notes                                                                           |
-| ---------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------- |
-| `cloudflare.apiToken`              | `""`                                | Required when Helm creates the credential secret.                               |
-| `cloudflare.accountId`             | `""`                                | Required when Helm creates the credential secret.                               |
-| `cloudflare.tunnelName`            | `""`                                | Required when Helm creates the credential secret.                               |
-| `cloudflare.secretRef.*`           | unset                               | Point the chart at an existing secret managed outside Helm.                     |
-| `ingressClass.name`                | `cloudflare-tunnel`                 | Rename if you run multiple controllers in one cluster.                          |
-| `ingressClass.isDefaultClass`      | `false`                             | Set to `true` only if Cloudflare Tunnel should handle every ingress by default. |
-| `cloudflared.image.tag`            | `latest`                            | Pin to a specific cloudflared version for reproducible environments.            |
-| `cloudflared.replicaCount`         | `1`                                 | Number of cloudflared connector pods maintaining the tunnel.                    |
-| `cloudflared.podAntiAffinity`      | `false`                             | Spread connector pods across nodes with a required anti-affinity. Needs at least as many schedulable nodes as replicas, otherwise the extra pods stay pending. Ignored when `cloudflared.affinity` is set. |
-| `cloudflared.extraArgs`            | `[]`                                | Append extra arguments such as `--post-quantum`.                                |
-| `cloudflaredServiceMonitor.create` | `false`                             | Enable when you scrape metrics with Prometheus Operator.                        |
-| `replicaCount`                     | `1`                                 | Scale the controller deployment (enable leader election for >1).                |
-| `resources`                        | requests/limits at 100m CPU / 128Mi | Harden resource guarantees for both the controller and connectors.              |
+## Credentials and ingress
 
-Most other values control standard Kubernetes objects (service account, annotations, node selectors, tolerations, affinity). Use them to integrate with your platform’s scheduling or security requirements.
+| Value                         | Default             | Notes                                                                                      |
+| ----------------------------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| `cloudflare.apiToken`         | `""`                | Required when Helm creates the credential Secret.                                          |
+| `cloudflare.accountId`        | `""`                | Required when Helm creates the credential Secret.                                          |
+| `cloudflare.tunnelName`       | `""`                | Required when Helm creates the credential Secret.                                          |
+| `cloudflare.secretRef.*`      | unset               | Use an existing Secret. Set `name`, `accountIDKey`, `tunnelNameKey`, and `apiTokenKey`.    |
+| `ingressClass.name`           | `cloudflare-tunnel` | Name of the `IngressClass` created and watched by the controller.                          |
+| `ingressClass.isDefaultClass` | `false`             | Set to `true` only if Cloudflare Tunnel should handle ingresses without an explicit class. |
+
+## Controller pods
+
+These values apply to the controller Deployment, not the managed cloudflared connector Deployment.
+
+| Value                | Default                                                              | Notes                                                                                        |
+| -------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `replicaCount`       | `1`                                                                  | Number of controller pods. Enable `leaderElection.enabled` when using more than one replica. |
+| `resources`          | CPU requests and limits: `100m`; memory requests and limits: `128Mi` | Controller container resource requests and limits.                                           |
+| `securityContext`    | `{}`                                                                 | Kubernetes container security context for the controller container.                          |
+| `podSecurityContext` | `{}`                                                                 | Kubernetes pod security context for controller pods.                                         |
+| `priorityClassName`  | unset                                                                | PriorityClass assigned to controller pods.                                                   |
+
+## Managed cloudflared connector pods
+
+The chart writes these values to the deployment customization file consumed by the controller.
+
+| Value                                   | Default  | Notes                                                                                                                                                                               |
+| --------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cloudflared.image.tag`                 | `latest` | Image tag for managed cloudflared connector pods.                                                                                                                                   |
+| `cloudflared.replicaCount`              | `1`      | Number of cloudflared connector pods maintaining the tunnel.                                                                                                                        |
+| `cloudflared.extraArgs`                 | `[]`     | Extra arguments passed to cloudflared, such as `--post-quantum`.                                                                                                                    |
+| `cloudflared.resources`                 | `{}`     | Container resource requests and limits.                                                                                                                                             |
+| `cloudflared.securityContext`           | `{}`     | Kubernetes container security context for the cloudflared container.                                                                                                                |
+| `cloudflared.podSecurityContext`        | `{}`     | Kubernetes pod security context for connector pods.                                                                                                                                 |
+| `cloudflared.podAntiAffinity`           | `false`  | Adds required pod anti-affinity across `kubernetes.io/hostname`. Ignored when `cloudflared.affinity` is set. Extra replicas stay pending if there are not enough schedulable nodes. |
+| `cloudflared.topologySpreadConstraints` | `[]`     | Kubernetes topology spread constraints for connector pods.                                                                                                                          |
+| `cloudflared.priorityClassName`         | unset    | PriorityClass assigned to connector pods.                                                                                                                                           |
+| `cloudflared.probes.liveness`           | `{}`     | Kubernetes liveness probe for the cloudflared container.                                                                                                                            |
+| `cloudflared.probes.readiness`          | `{}`     | Kubernetes readiness probe for the cloudflared container.                                                                                                                           |
+| `cloudflared.probes.startup`            | `{}`     | Kubernetes startup probe for the cloudflared container.                                                                                                                             |
+| `cloudflared.volumes`                   | `[]`     | Kubernetes volumes added to connector pods.                                                                                                                                         |
+| `cloudflared.volumeMounts`              | `[]`     | Kubernetes volume mounts added to the cloudflared container.                                                                                                                        |
+| `cloudflared.pdb.enabled`               | `false`  | Create a PodDisruptionBudget for connector pods.                                                                                                                                    |
+| `cloudflared.pdb.minAvailable`          | unset    | Minimum available connector pods. Mutually exclusive with `cloudflared.pdb.maxUnavailable`.                                                                                         |
+| `cloudflared.pdb.maxUnavailable`        | unset    | Maximum unavailable connector pods. Mutually exclusive with `cloudflared.pdb.minAvailable`.                                                                                         |
+
+## Cloudflared ServiceMonitor
+
+These values configure the Prometheus Operator `ServiceMonitor` for managed cloudflared connectors.
+
+| Value                                         | Default | Notes                                                                                      |
+| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `cloudflaredServiceMonitor.create`            | `false` | Create the ServiceMonitor.                                                                 |
+| `cloudflaredServiceMonitor.jobLabel`          | `""`    | Service label used as the Prometheus job name. Omitted from the ServiceMonitor when empty. |
+| `cloudflaredServiceMonitor.interval`          | `""`    | Scrape interval. Omitted from the endpoint when empty.                                     |
+| `cloudflaredServiceMonitor.scrapeTimeout`     | `""`    | Scrape timeout. Omitted from the endpoint when empty.                                      |
+| `cloudflaredServiceMonitor.honorLabels`       | `false` | Preserve labels from scraped metrics when they conflict with server-side labels.           |
+| `cloudflaredServiceMonitor.metricRelabelings` | `[]`    | Metric relabeling rules applied after scraping.                                            |
+| `cloudflaredServiceMonitor.relabelings`       | `[]`    | Target relabeling rules applied before scraping.                                           |
+| `cloudflaredServiceMonitor.labels`            | `{}`    | Additional labels added to the ServiceMonitor.                                             |
+| `cloudflaredServiceMonitor.scheme`            | `http`  | Scheme used to scrape the metrics endpoint.                                                |


### PR DESCRIPTION
## Problem

`reference/controller-configuration.md` is missing the `-v` shorthand of `--log-level` and the default values that only exist in the README flag table, so neither page is a single source of truth. `reference/helm-values.md` does not cover several chart values (`cloudflared.pdb`, `cloudflared.probes`, `topologySpreadConstraints`, `volumes`/`volumeMounts`, `securityContext`/`podSecurityContext`, `priorityClassName`, `cloudflaredServiceMonitor` sub-options).

Part of #334.

## Solution

Make `controller-configuration.md` the single source of truth for all flags (including defaults) and document every missing helm value, all verified against `main.go`, `values.yaml`, and the chart templates.

## Major Changes

- `docs/src/content/docs/reference/controller-configuration.md`
  - Full 16-flag table with flag name, env var, default, and description; defaults merged from the README table.
  - Documents `-v` as the shorthand of `--log-level`.
- `docs/src/content/docs/reference/helm-values.md`
  - Adds the previously undocumented values listed above, including all `cloudflaredServiceMonitor` sub-options.

The README-side removal of the duplicated flag table happens in #336; merge this PR first.

Docs were written by Codex (gpt-5.6-sol) and verified against the sources by a separate review agent.