### PR TITLE
docs: add symptom-oriented troubleshooting page

### DIFF
--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -1,0 +1,119 @@
+---
+title: Troubleshooting
+description: Diagnose common Ingress, DNS, tunnel, and credential problems.
+---
+
+Use this flow to find the right section:
+
+```mermaid
+flowchart TD
+    symptom{"What is the symptom?"}
+    symptom -->|"Ingress not exposed"| events["Check Ingress events"]
+    events --> ingressSection["Go to: Ingress is not exposed"]
+    symptom -->|"DNS record missing"| dns["Check controller logs and DNS records"]
+    dns --> dnsSection["Go to: DNS record is missing"]
+    symptom -->|"Tunnel returns 502"| connectorLogs["Check cloudflared logs"]
+    connectorLogs --> tunnelSection["Go to: Tunnel connects but returns 502"]
+    symptom -->|"Credentials stay stale"| credentials["Check Secret update and controller restart"]
+    credentials --> credentialsSection["Go to: Credentials rotated but the controller still uses the old token"]
+```
+
+Start by checking that the controller and connector pods are running:
+
+```bash
+kubectl get pods -n cloudflare-tunnel-ingress-controller
+```
+
+If you used a different Helm release name or namespace, replace them in the commands below.
+
+## Ingress is not exposed
+
+Check that the Ingress uses the `cloudflare-tunnel` class, then inspect its events:
+
+```bash
+kubectl get ingress <name> -n <namespace> -o yaml
+kubectl describe ingress <name> -n <namespace>
+```
+
+The controller reports these warnings:
+
+| Reason            | Event message                                                                     | What to check                                                                                               |
+| ----------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `RuleSkipped`     | `rule for host <host> has no http section, skipped`                               | Add an `http` section to the rule. Only this rule is skipped.                                               |
+| `TLSIgnored`      | `ingress has tls specified, SSL Passthrough is not supported, it will be ignored` | Remove the `tls` section. Cloudflare terminates TLS at the edge.                                            |
+| `TransformFailed` | `<transformation error>`                                                          | Fix the error in the event message. All routes from this Ingress are skipped until transformation succeeds. |
+
+```mermaid
+flowchart TD
+    change["Ingress change"] --> classCheck{"Uses cloudflare-tunnel class?"}
+    classCheck -->|No| ignored["Controller ignores Ingress"]
+    classCheck -->|Yes| tls{"TLS configured?"}
+    tls -->|Yes| tlsIgnored["TLSIgnored: ignore TLS settings"]
+    tls -->|No| transform["Transform rules"]
+    tlsIgnored --> transform
+    transform --> result{"Transform result"}
+    result -->|"Rule has no http section"| ruleSkipped["RuleSkipped: skip that rule"]
+    ruleSkipped --> transform
+    result -->|Error| transformFailed["TransformFailed: skip all routes from this Ingress"]
+    result -->|Success| reconcile["Reconcile tunnel routes and managed DNS"]
+```
+
+Common `TransformFailed` messages:
+
+- `fetch service <namespace>/<service>: ...` when the backend Service does not exist.
+- `service <namespace>/<service> has None for cluster ip, headless service is not supported`.
+- `service <namespace>/<service> has no port named <port>`.
+- `path type in ingress <namespace>/<name> is <pathType>, which is not supported`.
+
+Check controller logs for reconciliation errors:
+
+```bash
+kubectl logs deployment/cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+## DNS record is missing
+
+Check the public DNS response, then check controller logs for Cloudflare API, zone, and DNS reconciliation errors:
+
+```bash
+dig <hostname>
+kubectl logs deployment/cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+Verify that:
+
+- The API token can edit Cloudflare Tunnel and DNS resources and can read the zone.
+- The hostname belongs to a zone in the configured Cloudflare account.
+- The Ingress does not set [`disable-dns-management: "true"`](/reference/ingress-annotations/#disabling-dns-management).
+
+## Tunnel connects but returns 502
+
+A connected tunnel with a `502` response usually cannot reach the backend Service. Check the Service, port, and ready endpoints:
+
+```bash
+kubectl get service <service> -n <namespace>
+kubectl get endpointslice -n <namespace> \
+  -l kubernetes.io/service-name=<service>
+```
+
+Then inspect connector logs for the origin connection error:
+
+```bash
+kubectl logs deployment/controlled-cloudflared-connector \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+If the backend expects HTTPS or a specific host name, verify the relevant [Ingress annotations](/reference/ingress-annotations/).
+
+## Credentials rotated but the controller still uses the old token
+
+The controller reads credentials once at startup. Updating the Secret does not refresh a running controller. Restart the controller after rotating credentials:
+
+```bash
+kubectl rollout restart deployment cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+See [Cloudflare credentials](/reference/cloudflare-credentials/) for the full credential setup and rotation caveat.

--- a/docs/src/content/docs/reference/ingress.md
+++ b/docs/src/content/docs/reference/ingress.md
@@ -19,29 +19,7 @@ Each ingress assigned to the `cloudflare-tunnel` class becomes a Cloudflare rout
 | `spec.rules[].http.paths[].backend.service.name` | Target Kubernetes Service name.                  |
 | `spec.rules[].http.paths[].backend.service.port` | Service port number or name to proxy.            |
 
-Example manifest:
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: dashboard
-  namespace: kubernetes-dashboard
-  annotations:
-    kubernetes.io/ingress.class: cloudflare-tunnel
-spec:
-  rules:
-    - host: dash.example.com # <- REPLACE ME!
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kubernetes-dashboard
-                port:
-                  number: 80
-```
+See the [Quickstart Ingress example](/guides/quickstart/#3-publish-a-service-with-ingress) for a complete dashboard manifest. Set `spec.ingressClassName` or the legacy `kubernetes.io/ingress.class` annotation to `cloudflare-tunnel`, then provide the host, backend Service, and port described above.
 
 Consult the [ingress annotations reference](/reference/ingress-annotations/) for advanced routing behaviour such as protocol overrides, TLS verification settings, and host header rewrites.
 
@@ -55,14 +33,6 @@ Hosts may use a leading wildcard label such as `*.example.com`. The controller c
 
 The order of rules inside your Ingress spec does not matter. The controller sorts them deterministically before writing the tunnel configuration.
 
-## Troubleshooting with events
+## Troubleshooting
 
-The Ingress API has no status conditions, so the controller reports problems as Warning events on the Ingress object. Check them with `kubectl describe ingress <name>`:
-
-| Reason            | Meaning                                                                                                          |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `RuleSkipped`     | A rule carries only a host and no `http` section, so it cannot be turned into a tunnel route.                    |
-| `TLSIgnored`      | The ingress has a `tls` section. SSL passthrough is not supported, Cloudflare terminates TLS at the edge.        |
-| `TransformFailed` | A rule could not be transformed, for example a headless Service, a missing Service, or an unsupported `pathType`. |
-
-Rules that fail to transform are skipped while the remaining rules still reconcile, so a single broken rule does not take down the other routes of the ingress.
+See the [troubleshooting guide](/guides/troubleshooting/) for Ingress warning events, log commands, and common DNS and tunnel problems.


### PR DESCRIPTION
## Problem

Troubleshooting knowledge is scattered: the Kubernetes events table lives in `reference/ingress.md`, log-checking tips in the quickstart, and the credential-rotation caveat in `cloudflare-credentials.md`. There is no single page a user can scan when something breaks. `reference/ingress.md` also duplicates the dashboard Ingress manifest from the quickstart.

Part of #334.

## Solution

Add a symptom-oriented troubleshooting page consolidating all of it, with Mermaid decision-tree diagrams for fast scanning, and slim `reference/ingress.md` back to pure reference.

## Major Changes

- `docs/src/content/docs/guides/troubleshooting.md` (new)
  - Sections by symptom: Ingress not exposed, DNS record missing, tunnel connects but 502, credentials rotated but controller still uses the old token.
  - A symptom-routing flowchart at the top and an event-flow diagram (`TLSIgnored` / `RuleSkipped` per-rule skip / `TransformFailed` whole-Ingress drop), both verified against `pkg/controller/transform.go` behavior. This also fixes a factual error in the old events table, which claimed a broken rule never affects the other routes of the same Ingress.
- `docs/src/content/docs/reference/ingress.md`
  - Events table and the duplicated dashboard manifest replaced with links; keeps the reference-only field explanations.

Merge order note: merge after #335, which adds the astro-mermaid rendering support; until then the diagrams degrade to code blocks (build is unaffected). The sidebar entry for this page is added in the upcoming sidebar reorganization PR.

Docs were written by Codex (gpt-5.6-sol) and verified against the sources by a separate review agent.