### PR TITLE
docs: add how-to guide series

### DIFF
--- a/docs/src/content/docs/how-to/expose-non-http-services.md
+++ b/docs/src/content/docs/how-to/expose-non-http-services.md
@@ -1,0 +1,73 @@
+---
+title: Expose Non HTTP Services
+description: Publish TCP, SSH, RDP, and other supported services through Cloudflare Tunnel.
+---
+
+Use the `backend-protocol` annotation when a Kubernetes Service does not speak HTTP.
+
+The controller uses the annotation value as the scheme in the `cloudflared` service URL. For example, `tcp` becomes `tcp://service.namespace.svc.cluster.local:port`, while `ssh` and `rdp` become `ssh://...` and `rdp://...`. The controller passes other schemes through without validation, so confirm that your `cloudflared` version supports the protocol before using it.
+
+See [Ingress annotations](/reference/ingress-annotations/) for the annotation name and default.
+
+```mermaid
+flowchart LR
+    Client["Client"] --> Edge["Cloudflare edge"]
+    Edge --> Connector["Managed cloudflared connector"]
+    Connector -->|"tcp://, ssh://, or rdp://"| Service["Kubernetes Service"]
+```
+
+## 1. Create one Ingress for the service
+
+Create an Ingress with one host and one backend. This example publishes a PostgreSQL Service over TCP:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: postgres-tunnel
+  namespace: database
+  annotations:
+    cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: tcp
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+    - host: postgres.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: postgres
+                port:
+                  number: 5432
+```
+
+The Kubernetes Ingress API still requires the `http.paths` structure. Use `/` as the placeholder path. The controller omits the path from every tunnel rule whose service URL does not start with `http://` or `https://`.
+
+For SSH, set the annotation value to `ssh` and select the Service port that serves SSH. For RDP, use `rdp` and its Service port.
+
+Keep different backend protocols in separate Ingress resources. The annotation applies to every rule and path in one Ingress.
+
+## 2. Apply the Ingress
+
+```bash
+kubectl apply -f postgres-tunnel.yaml
+```
+
+## 3. Check reconciliation
+
+Inspect the Ingress for warning events:
+
+```bash
+kubectl describe ingress postgres-tunnel -n database
+```
+
+Then check the controller log if the Cloudflare route was not accepted:
+
+```bash
+kubectl logs deployment/cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+The resulting tunnel rule sends `postgres.example.com` to `tcp://postgres.database.svc.cluster.local:5432` when the cluster domain is the default `cluster.local`.

--- a/docs/src/content/docs/how-to/expose-non-http-services.md
+++ b/docs/src/content/docs/how-to/expose-non-http-services.md
@@ -71,3 +71,80 @@ kubectl logs deployment/cloudflare-tunnel-ingress-controller \
 ```
 
 The resulting tunnel rule sends `postgres.example.com` to `tcp://postgres.database.svc.cluster.local:5432` when the cluster domain is the default `cluster.local`.
+
+## Connect from a client
+
+Install [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/) on every client device that will connect. These commands assume that the hostname is protected by a Cloudflare Access application and policy.
+
+```mermaid
+flowchart LR
+    Tool["redis-cli, psql, or ssh"] --> LocalProxy["Client cloudflared proxy"]
+    LocalProxy --> Access["Cloudflare edge and Access"]
+    Access --> Connector["Managed cloudflared connector"]
+    Connector --> Service["Kubernetes Service"]
+```
+
+### Connect to Redis
+
+Expose Redis with the same Ingress pattern used above. Set `backend-protocol` to `tcp`, use a host such as `redis.example.com`, and select the Redis Service port `6379`.
+
+Start a local TCP proxy on any available client port:
+
+```bash
+cloudflared access tcp \
+  --hostname redis.example.com \
+  --url localhost:16379
+```
+
+Keep that command running. In another terminal, point `redis-cli` at the local port:
+
+```bash
+redis-cli -h localhost -p 16379
+```
+
+### Connect to PostgreSQL
+
+Start a local proxy for the `postgres.example.com` hostname created earlier:
+
+```bash
+cloudflared access tcp \
+  --hostname postgres.example.com \
+  --url localhost:15432
+```
+
+Keep that command running. Connect `psql` to the local port:
+
+```bash
+psql \
+  --host localhost \
+  --port 15432 \
+  --username "<DATABASE_USER>" \
+  --dbname "<DATABASE_NAME>"
+```
+
+See Cloudflare's [arbitrary TCP guide](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/non-http/cloudflared-authentication/arbitrary-tcp/) for Access setup and client authentication details.
+
+### Connect to SSH
+
+Expose the SSH Service with `backend-protocol: ssh`. Add this block to `~/.ssh/config`, replacing the hostname:
+
+```text
+Host ssh.example.com
+  ProxyCommand cloudflared access ssh --hostname %h
+```
+
+If `cloudflared` is not in the SSH client's `PATH`, use its absolute path in `ProxyCommand`.
+
+Connect with the normal SSH command:
+
+```bash
+ssh user@ssh.example.com
+```
+
+See Cloudflare's [SSH with client side cloudflared guide](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-cloudflared-authentication/) for the complete Access setup.
+
+### Use WARP for team access
+
+For managed teams, Cloudflare One Client in WARP mode plus Zero Trust private network routes is an alternative. Users can connect normal client tools to private addresses without starting a hostname specific `cloudflared access` command for each session.
+
+See Cloudflare's [private networks guide](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/) for the routing and client enrollment workflow.

--- a/docs/src/content/docs/how-to/high-availability.md
+++ b/docs/src/content/docs/how-to/high-availability.md
@@ -1,0 +1,119 @@
+---
+title: Configure High Availability
+description: Run redundant controller and cloudflared replicas across failure domains.
+---
+
+Use multiple controller replicas for reconciliation availability and multiple `cloudflared` replicas for tunnel connectivity.
+
+See [Helm values](/reference/helm-values/) for defaults and the complete chart values file.
+
+```mermaid
+flowchart TB
+    subgraph Controllers["Controller Deployment"]
+        ControllerA["Controller replica"]
+        ControllerB["Controller replica"]
+        Lease[("Leader election Lease")]
+        ControllerA -->|"competes"| Lease
+        ControllerB -->|"competes"| Lease
+    end
+
+    Lease -->|"one active leader"| Reconcile["Ingress and connector reconciliation"]
+    Reconcile --> Deployment["Managed cloudflared Deployment"]
+
+    subgraph Cluster["Kubernetes cluster"]
+        subgraph NodeA["Node A"]
+            ConnectorA["cloudflared replica"]
+        end
+        subgraph NodeB["Node B"]
+            ConnectorB["cloudflared replica"]
+        end
+    end
+
+    Deployment --> ConnectorA
+    Deployment --> ConnectorB
+    ConnectorA --> Edge["Cloudflare edge"]
+    ConnectorB --> Edge
+```
+
+## 1. Scale the controller with leader election
+
+Add these values to the values file used for your existing Helm release:
+
+```yaml
+replicaCount: 2
+
+leaderElection:
+  enabled: true
+```
+
+`replicaCount` scales the controller Deployment. `leaderElection.enabled: true` adds the `--leader-elect` flag to every controller pod. That flag enables controller runtime leader election with the lock named `cloudflare-tunnel-ingress-controller.strrl.dev` in the controller namespace.
+
+If you run the binary without Helm, pass `--leader-elect` directly. The Helm value and command flag are two interfaces for the same controller setting.
+
+## 2. Scale and protect cloudflared
+
+Add connector replicas and a PodDisruptionBudget:
+
+```yaml
+cloudflared:
+  replicaCount: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+```
+
+Use either `minAvailable` or `maxUnavailable`, never both.
+
+## 3. Spread connector pods across nodes
+
+For strict separation by node, enable the chart shortcut:
+
+```yaml
+cloudflared:
+  podAntiAffinity: true
+```
+
+This creates required pod anti affinity on `kubernetes.io/hostname`. The cluster needs at least as many schedulable nodes as connector replicas. Extra replicas remain pending when no eligible node is available.
+
+An explicit `cloudflared.affinity` value takes precedence and disables this shortcut.
+
+## 4. Spread connector pods across zones
+
+Add a topology spread constraint when the cluster labels nodes by zone:
+
+```yaml
+cloudflared:
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app: controlled-cloudflared-connector
+```
+
+You can use this with node anti affinity. Change `whenUnsatisfiable` to `DoNotSchedule` only when every required failure domain has enough schedulable capacity.
+
+## 5. Upgrade the release
+
+Merge these settings into the existing release values, then run your normal Helm upgrade. Do not replace existing Cloudflare credential values with empty chart defaults.
+
+## 6. Verify redundancy
+
+Check the controller Deployment, election lock, connector Deployment, and disruption budget:
+
+```bash
+kubectl get deployment cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller
+
+kubectl get lease cloudflare-tunnel-ingress-controller.strrl.dev \
+  -n cloudflare-tunnel-ingress-controller
+
+kubectl get deployment controlled-cloudflared-connector \
+  -n cloudflare-tunnel-ingress-controller
+
+kubectl get pdb controlled-cloudflared-connector \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+Confirm all requested replicas are available and connector pods run on the intended nodes or zones.

--- a/docs/src/content/docs/how-to/index.md
+++ b/docs/src/content/docs/how-to/index.md
@@ -1,0 +1,12 @@
+---
+title: How To Guides
+description: Complete common operational tasks with a running Cloudflare Tunnel Ingress Controller.
+---
+
+Use these guides after the controller and its managed `cloudflared` connectors are running.
+
+1. [Expose non HTTP services](/how-to/expose-non-http-services/): Publish TCP, SSH, RDP, and other supported service protocols.
+2. [Use an external DNS system](/how-to/use-with-external-dns/): Hand DNS ownership to ExternalDNS or a Cloudflare Load Balancer.
+3. [Configure high availability](/how-to/high-availability/): Run redundant controller and `cloudflared` replicas across failure domains.
+4. [Monitor the controller and cloudflared](/how-to/monitoring/): Scrape metrics and add health probes.
+5. [Rotate Cloudflare credentials](/how-to/rotate-cloudflare-credentials/): Replace the API token without leaving workloads on stale credentials.

--- a/docs/src/content/docs/how-to/monitoring.md
+++ b/docs/src/content/docs/how-to/monitoring.md
@@ -1,0 +1,122 @@
+---
+title: Monitor the Controller and cloudflared
+description: Scrape controller and cloudflared metrics and configure connector health probes.
+---
+
+The controller and its managed `cloudflared` connectors expose separate metrics endpoints.
+
+See [Helm values](/reference/helm-values/) for chart defaults.
+
+## Inspect controller metrics
+
+The controller serves controller runtime metrics over HTTP at `/metrics` on port `8080`. The chart does not create a Service or ServiceMonitor for this endpoint.
+
+Forward the port from one controller pod:
+
+```bash
+kubectl port-forward deployment/cloudflare-tunnel-ingress-controller \
+  -n cloudflare-tunnel-ingress-controller \
+  8080:8080
+```
+
+Read the endpoint from another terminal:
+
+```bash
+curl http://127.0.0.1:8080/metrics
+```
+
+Create your own Service and scrape configuration if Prometheus must collect controller metrics continuously.
+
+## Inspect cloudflared metrics
+
+Every managed `cloudflared` process listens on `0.0.0.0:44483`. The chart always creates the `controlled-cloudflared-connector-headless` Service with a `metrics` port at `44483`.
+
+Forward that Service and read one connector:
+
+```bash
+kubectl port-forward service/controlled-cloudflared-connector-headless \
+  -n cloudflare-tunnel-ingress-controller \
+  44483:44483
+```
+
+```bash
+curl http://127.0.0.1:44483/metrics
+```
+
+When `cloudflaredServiceMonitor.create` is false, the Service carries `prometheus.io/scrape: "true"` and `prometheus.io/port: "44483"` annotations for annotation based discovery.
+
+## Create a cloudflared ServiceMonitor
+
+Prometheus Operator must be installed before you enable this object. Add the following settings to the values file used by the existing release:
+
+```yaml
+cloudflaredServiceMonitor:
+  create: true
+  labels:
+    release: kube-prometheus-stack
+  jobLabel: app.kubernetes.io/component
+  scheme: http
+  interval: 30s
+  scrapeTimeout: 10s
+  honorLabels: false
+  metricRelabelings: []
+  relabelings: []
+```
+
+Adjust each field for your Prometheus installation:
+
+1. `create` renders the ServiceMonitor.
+2. `labels` adds metadata labels, commonly used by a Prometheus selector.
+3. `jobLabel` names the selected Service label used as the Prometheus job label.
+4. `scheme` sets the scrape scheme.
+5. `interval` sets the scrape interval.
+6. `scrapeTimeout` sets the timeout for one scrape.
+7. `honorLabels` controls whether labels from scraped metrics take precedence.
+8. `metricRelabelings` adds metric relabel rules after a scrape.
+9. `relabelings` adds target relabel rules before a scrape.
+
+The generated ServiceMonitor selects only the managed connector Service in the Helm release namespace and scrapes its named `metrics` port at `/metrics`.
+
+Run your normal Helm upgrade, then verify the object:
+
+```bash
+kubectl get servicemonitor \
+  -n cloudflare-tunnel-ingress-controller
+```
+
+## Add cloudflared health probes
+
+The chart copies `cloudflared.probes.liveness`, `readiness`, and `startup` into the managed connector container as Kubernetes probe objects.
+
+This example uses the `cloudflared` readiness endpoint on the metrics port:
+
+```yaml
+cloudflared:
+  probes:
+    liveness:
+      httpGet:
+        path: /ready
+        port: 44483
+      initialDelaySeconds: 10
+    readiness:
+      httpGet:
+        path: /ready
+        port: 44483
+    startup:
+      httpGet:
+        path: /ready
+        port: 44483
+      failureThreshold: 30
+      periodSeconds: 2
+```
+
+Run your normal Helm upgrade, then inspect the managed Deployment and pods:
+
+```bash
+kubectl describe deployment controlled-cloudflared-connector \
+  -n cloudflare-tunnel-ingress-controller
+
+kubectl get pods \
+  -n cloudflare-tunnel-ingress-controller \
+  -l app=controlled-cloudflared-connector
+```

--- a/docs/src/content/docs/how-to/rotate-cloudflare-credentials.md
+++ b/docs/src/content/docs/how-to/rotate-cloudflare-credentials.md
@@ -1,0 +1,69 @@
+---
+title: Rotate Cloudflare Credentials
+description: Replace the controller API token and restart workloads that consume it.
+---
+
+Rotate the Cloudflare API token by updating its Kubernetes Secret and restarting the controller. The controller reads its credential environment variables only at startup.
+
+Review [Cloudflare credentials](/reference/cloudflare-credentials/) before starting. The replacement token needs the required permissions listed there.
+
+## 1. Create the replacement token
+
+Create a new Cloudflare API token with the same account, zone scope, and required permissions as the current token. Keep the current token valid until rotation is complete.
+
+## 2. Update the credential source
+
+Choose the method used by your Helm release.
+
+If Helm creates the `cloudflare-api` Secret, update `cloudflare.apiToken` in the secure values source used for the release, then run your normal Helm upgrade.
+
+If `cloudflare.secretRef` points to an existing Secret, update the key selected by `cloudflare.secretRef.apiTokenKey`. When an external secret controller owns that Secret, update the external provider and wait for the new value to sync into Kubernetes.
+
+Check that Kubernetes recorded a new Secret version without printing its contents:
+
+```bash
+kubectl get secret <SECRET_NAME> \
+  -n <CONTROLLER_NAMESPACE> \
+  -o jsonpath='{.metadata.resourceVersion}{"\n"}'
+```
+
+## 3. Restart the controller
+
+Restart the controller Deployment so every replica reads the replacement token:
+
+```bash
+kubectl rollout restart deployment <CONTROLLER_DEPLOYMENT> \
+  -n <CONTROLLER_NAMESPACE>
+```
+
+Wait for the rollout:
+
+```bash
+kubectl rollout status deployment <CONTROLLER_DEPLOYMENT> \
+  -n <CONTROLLER_NAMESPACE>
+```
+
+## 4. Verify Cloudflare reconciliation
+
+Check the new controller pods:
+
+```bash
+kubectl logs deployment/<CONTROLLER_DEPLOYMENT> \
+  -n <CONTROLLER_NAMESPACE> \
+  --since=10m
+```
+
+Confirm the controller can bootstrap the configured tunnel and reconcile existing Ingress resources without authentication errors.
+
+The elected controller also fetches the tunnel token for the managed `cloudflared` connector. If that token changes, the controller updates the `controlled-cloudflared-token` Secret and rolls the connector Deployment through its pod template annotation.
+
+Check connector availability:
+
+```bash
+kubectl rollout status deployment controlled-cloudflared-connector \
+  -n <CONTROLLER_NAMESPACE>
+```
+
+## 5. Revoke the old token
+
+Revoke the previous Cloudflare API token only after controller reconciliation and connector availability are healthy.

--- a/docs/src/content/docs/how-to/use-with-external-dns.md
+++ b/docs/src/content/docs/how-to/use-with-external-dns.md
@@ -1,0 +1,121 @@
+---
+title: Use an External DNS System
+description: Delegate hostname records to ExternalDNS or a Cloudflare Load Balancer.
+---
+
+Set `disable-dns-management: "true"` when another system must own DNS while this controller continues to manage the tunnel route.
+
+See [Ingress annotations](/reference/ingress-annotations/) for the annotation reference.
+
+## Before you begin
+
+Find the UUID of the tunnel used by the controller. Its Cloudflare Tunnel target is:
+
+```text
+<TUNNEL_ID>.cfargotunnel.com
+```
+
+Keep the Ingress in place throughout the handover. The controller still needs it to configure the matching tunnel ingress rule.
+
+## Hand ownership to ExternalDNS
+
+```mermaid
+flowchart TD
+    subgraph Before["Before handover"]
+        Controller["Cloudflare Tunnel Ingress Controller"]
+        ManagedCNAME["CNAME points to tunnel"]
+        ManagedTXT["_ctic_managed ownership TXT"]
+        Controller --> ManagedCNAME
+        Controller --> ManagedTXT
+    end
+
+    ManagedTXT --> Enable["Enable disable-dns-management"]
+    Enable --> DeleteTXT["Delete matching _ctic_managed TXT"]
+    Enable --> CheckCNAME{"CNAME still points to this tunnel?"}
+    CheckCNAME -->|"Yes"| DeleteCNAME["Delete direct tunnel CNAME"]
+    CheckCNAME -->|"No"| KeepCNAME["Keep repointed CNAME"]
+
+    DeleteTXT --> ExternalDNS["ExternalDNS reconciles"]
+    DeleteCNAME --> ExternalDNS
+    KeepCNAME --> ExternalDNS
+
+    subgraph After["After handover"]
+        ExternalCNAME["ExternalDNS owns CNAME"]
+        ExternalTXT["ExternalDNS ownership record when TXT registry is enabled"]
+    end
+
+    ExternalDNS --> ExternalCNAME
+    ExternalDNS -.-> ExternalTXT
+```
+
+### 1. Disable controller DNS management
+
+Add the annotation to the existing Ingress:
+
+```yaml
+metadata:
+  annotations:
+    cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management: "true"
+```
+
+Apply the updated manifest:
+
+```bash
+kubectl apply -f ingress.yaml
+```
+
+On its next reconciliation, the controller deletes its matching `_ctic_managed.<HOSTNAME>` ownership TXT record. It deletes the CNAME only while that record still points to this controller's `<TUNNEL_ID>.cfargotunnel.com` target. A repointed CNAME and records owned by another tunnel stay untouched.
+
+The tunnel ingress rule remains active. A hostname outside every zone available to the controller also stops causing a zone matching error when DNS management is disabled.
+
+### 2. Give ExternalDNS the tunnel target
+
+Configure ExternalDNS with the `ingress` source. Add its target annotation to the same Ingress:
+
+```yaml
+metadata:
+  annotations:
+    cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management: "true"
+    external-dns.alpha.kubernetes.io/target: "<TUNNEL_ID>.cfargotunnel.com"
+```
+
+The host in `spec.rules` supplies the record name. The ExternalDNS target override supplies the CNAME target.
+
+Apply the manifest, then wait for ExternalDNS to create the CNAME:
+
+```bash
+kubectl apply -f ingress.yaml
+kubectl logs deployment/external-dns -n external-dns
+```
+
+Plan a short DNS change window if the controller already owns the same CNAME. Disabling its management can remove that CNAME before ExternalDNS creates its replacement.
+
+### 3. Verify the handover
+
+Check the CNAME:
+
+```bash
+dig CNAME <HOSTNAME>
+```
+
+Confirm the CNAME targets `<TUNNEL_ID>.cfargotunnel.com`. If ExternalDNS uses its TXT registry, also confirm its configured ownership record exists.
+
+## Put a Cloudflare Load Balancer in front of the tunnel
+
+### 1. Create the Load Balancer origin
+
+Create a Cloudflare Load Balancer pool whose origin address is:
+
+```text
+<TUNNEL_ID>.cfargotunnel.com
+```
+
+Configure the Load Balancer hostname to match the host in the Kubernetes Ingress.
+
+### 2. Disable controller DNS management
+
+Add `disable-dns-management: "true"` to the Ingress and apply it. If the Load Balancer has already repointed the hostname away from the direct tunnel CNAME, the controller preserves that record and removes only its matching ownership TXT record.
+
+### 3. Verify both routing layers
+
+Confirm the Load Balancer hostname resolves through the expected pool. Keep the Kubernetes Ingress present so the controller continues to route that hostname through the tunnel to the Service.

--- a/docs/src/content/docs/reference/cloudflare-credentials.md
+++ b/docs/src/content/docs/reference/cloudflare-credentials.md
@@ -5,13 +5,30 @@ description: Provide the API token, account ID, and tunnel name required by the 
 
 The controller reads Cloudflare credentials from a Kubernetes secret named `cloudflare-api` in its namespace. The Helm chart can create this secret directly from the values you supply or consume an existing secret.
 
+## Create an API token
+
+1. Sign in to the Cloudflare dashboard.
+2. Open this token creation template:
+
+```text
+https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=[{"key":"zone","type":"read"},{"key":"dns","type":"edit"},{"key":"argotunnel","type":"edit"}]&name=Cloudflare%20Tunnel%20Ingress%20Controller&accountId=*&zoneId=all
+```
+
+3. Confirm that the token has all three required permission scopes:
+   1. `Zone:Zone:Read`
+   2. `Zone:DNS:Edit`
+   3. `Account:Cloudflare Tunnel:Edit`
+
+4. Review the account and zone resources covered by the token.
+5. Create the token and copy its value. Store this value under the `api-token` Secret key described below.
+
 ## Secret keys
 
-| Key                      | Purpose                                                                                                        |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| `api-token`              | Cloudflare API token with `Account.Cloudflare Tunnel:Edit`, `Zone.DNS:Edit`, and `Zone.Zone:Read` permissions. |
-| `cloudflare-account-id`  | Account identifier that owns the tunnel.                                                                       |
-| `cloudflare-tunnel-name` | Friendly tunnel name created or reused by the controller.                                                      |
+| Key                      | Purpose                                                                      |
+| ------------------------ | ---------------------------------------------------------------------------- |
+| `api-token`              | Cloudflare API token with the three required permission scopes listed above. |
+| `cloudflare-account-id`  | Account identifier that owns the tunnel.                                     |
+| `cloudflare-tunnel-name` | Friendly tunnel name created or reused by the controller.                    |
 
 To let Helm create the secret, pass the values during installation:
 
@@ -62,9 +79,6 @@ cloudflare:
     apiTokenKey: api_token
 ```
 
-The controller only needs read access to these values. The chart injects them into the controller pod as environment variables, and the controller reads them once at startup, so rotating the secret in place does not refresh a running controller. After updating the secret, restart the controller to pick up the new credentials:
+The controller only needs read access to these values. The chart injects them into the controller pod as environment variables, and the controller reads them once at startup.
 
-```bash
-kubectl rollout restart deployment cloudflare-tunnel-ingress-controller \
-  -n cloudflare-tunnel-ingress-controller
-```
+Follow [Rotate Cloudflare credentials](/how-to/rotate-cloudflare-credentials/) to replace a token and restart the workloads that consume it.

--- a/docs/src/content/docs/reference/ingress-annotations.md
+++ b/docs/src/content/docs/reference/ingress-annotations.md
@@ -5,41 +5,30 @@ description: Fine-tune Cloudflare Tunnel behaviour with controller-specific anno
 
 Annotations let you customise how the controller configures Cloudflare for each ingress rule. Apply them on the ingress metadata alongside the `cloudflare-tunnel` class.
 
-| Annotation                                                              | Purpose                                                                                                |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Annotation                                                              | Purpose                                                                                                                                               |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol`       | Protocol used to reach the backend Service (`http` default). Any protocol supported by cloudflared works, including `https`, `tcp`, `ssh`, and `rdp`. |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify`       | Enable (`on`) or disable (`off`) TLS verification when proxying to HTTPS backends.                     |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`       | Rewrite the HTTP Host header sent to the backend Service.                                              |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`     | Set the SNI hostname when terminating TLS to the origin.                                               |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management` | Set to `"true"` to stop the controller from managing Cloudflare DNS records for this ingress while still configuring the tunnel route. |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify`       | Enable (`on`) or disable (`off`) TLS verification when proxying to HTTPS backends.                                                                    |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`       | Rewrite the HTTP Host header sent to the backend Service.                                                                                             |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`     | Set the SNI hostname when terminating TLS to the origin.                                                                                              |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management` | Set to `"true"` to stop the controller from managing Cloudflare DNS records for this ingress while still configuring the tunnel route.                |
 
-Example ingress snippet:
+Example Ingress snippet:
 
 ```yaml
 metadata:
   name: dashboard
   namespace: kubernetes-dashboard
   annotations:
-    kubernetes.io/ingress.class: cloudflare-tunnel
     cloudflare-tunnel-ingress-controller.strrl.dev/backend-protocol: https
-    cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify: on
+    cloudflare-tunnel-ingress-controller.strrl.dev/proxy-ssl-verify: "on"
     cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header: dash.internal.svc
     cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name: dash.internal.svc
+spec:
+  ingressClassName: cloudflare-tunnel
 ```
 
-## Non HTTP backend protocols
-
-Set `backend-protocol` to `tcp`, `ssh`, `rdp`, or any other protocol cloudflared supports to expose non HTTP services. The Kubernetes Ingress spec still requires an `http.paths` entry for such rules, but the controller drops the path from the resulting tunnel rule because path based routing only exists for HTTP(S). Use `/` as a placeholder path.
-
-## Disabling DNS management
-
-Set `disable-dns-management: "true"` when DNS for a hostname is delegated to another system, for example external-dns or a Cloudflare Load Balancer in front of the tunnel. The controller keeps reconciling the tunnel ingress rule but no longer creates or updates the CNAME and ownership TXT records, and it stops erroring when the hostname belongs to no managed zone.
-
-If the controller previously managed DNS for the hostname, enabling the annotation makes it relinquish ownership instead of just going hands off:
-
-- The ownership TXT record it created is deleted.
-- Its CNAME record is deleted only while it still points at this tunnel. A CNAME already repointed by an external system is left untouched.
-- Records owned by a different tunnel are never touched.
+For task focused examples, see [Expose non HTTP services](/how-to/expose-non-http-services/) and [Use an external DNS system](/how-to/use-with-external-dns/).
 
 ## Validation feedback
 


### PR DESCRIPTION
## Problem

The How-to quadrant of the Divio documentation system is mostly missing: task-oriented content is scattered across reference pages (the external-dns walkthrough inside the annotations reference, the credential-rotation procedure inside the credentials reference), and common tasks like exposing non-HTTP services, high availability, and monitoring are not documented at all.

Part of #334.

## Solution

Add a five-guide how-to series under `how-to/`, move the misplaced task content there, and keep the reference pages as pure lookup material. Key concepts are illustrated with Mermaid diagrams instead of long prose.

## Major Changes

- `docs/src/content/docs/how-to/` (new, 6 pages)
  - `expose-non-http-services.md`: `backend-protocol` for TCP/SSH/RDP, with a traffic-flow diagram.
  - `use-with-external-dns.md`: `disable-dns-management`, with a DNS ownership handover diagram (CNAME/TXT behavior verified against `pkg/cloudflare-controller/dns.go`).
  - `high-availability.md`: `replicaCount`, the `--leader-elect` flag to `leaderElection.enabled` value mapping, `cloudflared.pdb`, `topologySpreadConstraints`, `podAntiAffinity`, with a topology diagram.
  - `monitoring.md`: controller and cloudflared metrics endpoints, all `cloudflaredServiceMonitor` sub-options, `cloudflared.probes`.
  - `rotate-cloudflare-credentials.md`: rotation procedure extracted from the credentials reference.
  - `index.md`: landing page.
- `docs/src/content/docs/reference/ingress-annotations.md`
  - Now a pure annotation reference; the external-dns walkthrough moved to the how-to, the HTTPS-backend annotation example kept (modernized to `ingressClassName`).
- `docs/src/content/docs/reference/cloudflare-credentials.md`
  - Gains the canonical API token creation instructions (README and quickstart stop duplicating them in #336); rotation steps replaced with a link to the how-to.

Merge order note: merge after #335 (astro-mermaid rendering support); diagrams degrade to code blocks until then. Sidebar entries for the new group are added in the upcoming sidebar reorganization PR.

Docs were written by Codex (gpt-5.6-sol) and verified against the sources by a separate review agent.