### PR TITLE
ci: keep e2e-test required check satisfied on docs-only changes

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -10,22 +10,45 @@ on:
   pull_request:
     branches:
       - "master"
-    paths-ignore:
-      - "docs/**"
 
 permissions: read-all
 
-# All e2e runs share one Cloudflare tunnel and zone. Two controllers running
-# at once treat each other's records as orphans and delete them in a loop,
-# so runs must be strictly serialized.
-concurrency:
-  group: e2e-shared-cloudflare-tunnel
-  cancel-in-progress: false
-
 jobs:
+  # The e2e-test job below is a required status check on master. Skipping the
+  # whole workflow via paths-ignore leaves the required check missing forever
+  # and blocks docs-only pull requests, so the workflow always runs and this
+  # job decides whether the e2e job itself runs. A skipped required job counts
+  # as satisfied.
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      non_docs: ${{ steps.filter.outputs.non_docs }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-docs changes
+        id: filter
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -v '^docs/' | grep -q .; then
+            echo "non_docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "non_docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
   e2e-test:
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || (needs.changes.result == 'success' && needs.changes.outputs.non_docs == 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # All e2e runs share one Cloudflare tunnel and zone. Two controllers running
+    # at once treat each other's records as orphans and delete them in a loop,
+    # so runs must be strictly serialized.
+    concurrency:
+      group: e2e-shared-cloudflare-tunnel
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Problem

The master ruleset requires the `e2e-test` status check, but #333 skips the whole workflow for docs-only changes via `paths-ignore: docs/**`. A workflow that never triggers reports no check at all, so every docs-only PR (for example #335 through #340) stays permanently BLOCKED and can only be merged with admin privileges.

## Solution

Always trigger the workflow on pull requests and decide at the job level instead: a tiny `changes` job detects whether the PR touches anything outside `docs/`, and the `e2e-test` job is skipped when it does not. GitHub treats a skipped required job as satisfied, so docs-only PRs pass the ruleset while code PRs still run the full e2e suite. Runner cost stays the same as before: the skipped job never starts minikube or the tunnel.

## Major Changes

- `.github/workflows/e2e-test.yaml`
  - `paths-ignore` removed; new `changes` job computes a `non_docs` output via `git diff` against the base branch.
  - `e2e-test` gates on that output, with `workflow_dispatch` continuing to run unconditionally (`!cancelled()` keeps the job eligible when `changes` is skipped on manual dispatch).
  - The shared-tunnel `concurrency` group moved from workflow level to the `e2e-test` job, so docs-only runs no longer queue behind a real e2e run.

This PR itself touches a non-docs file, so it exercises the new path end to end: `changes` should report `non_docs=true` and the real e2e suite should run.