### PR TITLE
feat: support cloudflared originRequest settings via ingress annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Pre-commit hooks are managed via [prek](https://prek.j178.dev/) (configured in `
 - `cloudflare-tunnel-ingress-controller.strrl.dev/http-host-header`: Set HTTP Host header for the local webserver
 - `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`: Hostname on the origin server certificate
 - `cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management`: Disable Cloudflare DNS record (CNAME/TXT) management for the ingress while still configuring the tunnel ingress rule, so DNS can be delegated to an external system such as external-dns or a Cloudflare Load Balancer ("true" or "false", default "false")
+- Origin request settings mapping to cloudflared `originRequest` fields (see `pkg/controller/well_known_annotations.go`): `connect-timeout`, `tls-timeout`, `tcp-keepalive`, `no-happy-eyeballs`, `keepalive-connections`, `keepalive-timeout`, `no-tls-verify`, `disable-chunked-encoding`, `http2-origin`
 
 ## Testing Strategy
 

--- a/docs/src/content/docs/reference/ingress-annotations.md
+++ b/docs/src/content/docs/reference/ingress-annotations.md
@@ -15,7 +15,7 @@ Annotations let you customise how the controller configures Cloudflare for each 
 
 ## Origin request settings
 
-These annotations map to cloudflared `originRequest` settings and apply to every rule generated from the ingress. Omitted annotations keep the cloudflared defaults. Durations are Go duration strings in whole seconds, such as `30s` or `2m`. See the upstream [origin configuration parameters](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/origin-parameters/) reference for the behaviour of each setting.
+These annotations map to cloudflared `originRequest` settings and apply to every rule generated from the ingress. Omitted annotations keep the cloudflared defaults, with one historical exception: for `backend-protocol: https` the controller disables TLS verification unless told otherwise, so enable verification explicitly with `no-tls-verify: "false"` (or the legacy `proxy-ssl-verify: "on"`). Durations are Go duration strings in whole seconds, such as `30s` or `2m`. See the upstream [origin configuration parameters](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/origin-parameters/) reference for the behaviour of each setting.
 
 | Annotation                                                                  | Purpose                                                                                                                  |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
@@ -27,7 +27,7 @@ These annotations map to cloudflared `originRequest` settings and apply to every
 | `cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-timeout`          | Timeout for closing idle connections to the origin.                                                                      |
 | `cloudflare-tunnel-ingress-controller.strrl.dev/no-tls-verify`              | Set to `"true"` to disable TLS certificate verification of the origin. Mutually exclusive with `proxy-ssl-verify`.       |
 | `cloudflare-tunnel-ingress-controller.strrl.dev/disable-chunked-encoding`   | Set to `"true"` to disable chunked transfer encoding towards the origin, useful for WSGI servers.                        |
-| `cloudflare-tunnel-ingress-controller.strrl.dev/http2-origin`               | Set to `"true"` to connect to the origin with HTTP/2.                                                                    |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/http2-origin`               | Set to `"true"` to connect to the origin with HTTP/2. Requires `backend-protocol: https`, HTTP/2 needs TLS.              |
 
 Example Ingress snippet:
 

--- a/docs/src/content/docs/reference/ingress-annotations.md
+++ b/docs/src/content/docs/reference/ingress-annotations.md
@@ -13,6 +13,22 @@ Annotations let you customise how the controller configures Cloudflare for each 
 | `cloudflare-tunnel-ingress-controller.strrl.dev/origin-server-name`     | Set the SNI hostname when terminating TLS to the origin.                                                                                              |
 | `cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management` | Set to `"true"` to stop the controller from managing Cloudflare DNS records for this ingress while still configuring the tunnel route.                |
 
+## Origin request settings
+
+These annotations map to cloudflared `originRequest` settings and apply to every rule generated from the ingress. Omitted annotations keep the cloudflared defaults. Durations are Go duration strings in whole seconds, such as `30s` or `2m`. See the upstream [origin configuration parameters](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/origin-parameters/) reference for the behaviour of each setting.
+
+| Annotation                                                                  | Purpose                                                                                                                  |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/connect-timeout`            | Timeout for establishing a new TCP connection to the origin.                                                             |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/tls-timeout`                | Timeout for completing a TLS handshake with the origin.                                                                  |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/tcp-keepalive`              | TCP keepalive interval for connections to the origin.                                                                    |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/no-happy-eyeballs`          | Set to `"true"` to disable the IPv4/IPv6 fallback when connecting to the origin.                                         |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-connections`      | Maximum keepalive connection pool size towards the origin.                                                               |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-timeout`          | Timeout for closing idle connections to the origin.                                                                      |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/no-tls-verify`              | Set to `"true"` to disable TLS certificate verification of the origin. Mutually exclusive with `proxy-ssl-verify`.       |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/disable-chunked-encoding`   | Set to `"true"` to disable chunked transfer encoding towards the origin, useful for WSGI servers.                        |
+| `cloudflare-tunnel-ingress-controller.strrl.dev/http2-origin`               | Set to `"true"` to connect to the origin with HTTP/2.                                                                    |
+
 Example Ingress snippet:
 
 ```yaml

--- a/pkg/cloudflare-controller/transform.go
+++ b/pkg/cloudflare-controller/transform.go
@@ -2,6 +2,7 @@ package cloudflarecontroller
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
@@ -26,56 +27,62 @@ func fromExposureToCloudflareIngress(ctx context.Context, exposure exposure.Expo
 		result.Path = exposure.PathPrefix
 	}
 
-	originRequest := func() *cloudflare.OriginRequestConfig {
-		if result.OriginRequest == nil {
-			result.OriginRequest = &cloudflare.OriginRequestConfig{}
-		}
-		return result.OriginRequest
-	}
+	result.OriginRequest = fromExposureToOriginRequest(exposure)
+
+	return &result, nil
+}
+
+// fromExposureToOriginRequest assembles the originRequest settings of a rule,
+// it returns nil when the exposure carries no origin request related setting.
+func fromExposureToOriginRequest(exposure exposure.Exposure) *cloudflare.OriginRequestConfig {
+	config := cloudflare.OriginRequestConfig{}
 
 	if exposure.HTTPHostHeader != nil {
-		originRequest().HTTPHostHeader = exposure.HTTPHostHeader
+		config.HTTPHostHeader = exposure.HTTPHostHeader
 	}
 
 	if strings.HasPrefix(exposure.ServiceTarget, "https://") {
-		originRequest().OriginServerName = exposure.OriginServerName
+		config.OriginServerName = exposure.OriginServerName
 		if exposure.ProxySSLVerifyEnabled == nil {
-			originRequest().NoTLSVerify = ptr.To(true)
+			config.NoTLSVerify = ptr.To(true)
 		} else {
-			originRequest().NoTLSVerify = ptr.To(!*exposure.ProxySSLVerifyEnabled)
+			config.NoTLSVerify = ptr.To(!*exposure.ProxySSLVerifyEnabled)
 		}
 	}
 
 	// direct no-tls-verify control takes precedence over the legacy
 	// proxy-ssl-verify derived value above
 	if exposure.NoTLSVerify != nil {
-		originRequest().NoTLSVerify = exposure.NoTLSVerify
+		config.NoTLSVerify = exposure.NoTLSVerify
 	}
 
 	if exposure.ConnectTimeout != nil {
-		originRequest().ConnectTimeout = &cloudflare.TunnelDuration{Duration: *exposure.ConnectTimeout}
+		config.ConnectTimeout = &cloudflare.TunnelDuration{Duration: *exposure.ConnectTimeout}
 	}
 	if exposure.TLSTimeout != nil {
-		originRequest().TLSTimeout = &cloudflare.TunnelDuration{Duration: *exposure.TLSTimeout}
+		config.TLSTimeout = &cloudflare.TunnelDuration{Duration: *exposure.TLSTimeout}
 	}
 	if exposure.TCPKeepAlive != nil {
-		originRequest().TCPKeepAlive = &cloudflare.TunnelDuration{Duration: *exposure.TCPKeepAlive}
+		config.TCPKeepAlive = &cloudflare.TunnelDuration{Duration: *exposure.TCPKeepAlive}
 	}
 	if exposure.KeepAliveTimeout != nil {
-		originRequest().KeepAliveTimeout = &cloudflare.TunnelDuration{Duration: *exposure.KeepAliveTimeout}
+		config.KeepAliveTimeout = &cloudflare.TunnelDuration{Duration: *exposure.KeepAliveTimeout}
 	}
 	if exposure.NoHappyEyeballs != nil {
-		originRequest().NoHappyEyeballs = exposure.NoHappyEyeballs
+		config.NoHappyEyeballs = exposure.NoHappyEyeballs
 	}
 	if exposure.KeepAliveConnections != nil {
-		originRequest().KeepAliveConnections = exposure.KeepAliveConnections
+		config.KeepAliveConnections = exposure.KeepAliveConnections
 	}
 	if exposure.DisableChunkedEncoding != nil {
-		originRequest().DisableChunkedEncoding = exposure.DisableChunkedEncoding
+		config.DisableChunkedEncoding = exposure.DisableChunkedEncoding
 	}
 	if exposure.HTTP2Origin != nil {
-		originRequest().Http2Origin = exposure.HTTP2Origin
+		config.Http2Origin = exposure.HTTP2Origin
 	}
 
-	return &result, nil
+	if reflect.DeepEqual(config, cloudflare.OriginRequestConfig{}) {
+		return nil
+	}
+	return &config
 }

--- a/pkg/cloudflare-controller/transform.go
+++ b/pkg/cloudflare-controller/transform.go
@@ -26,23 +26,55 @@ func fromExposureToCloudflareIngress(ctx context.Context, exposure exposure.Expo
 		result.Path = exposure.PathPrefix
 	}
 
-	if exposure.HTTPHostHeader != nil {
+	originRequest := func() *cloudflare.OriginRequestConfig {
 		if result.OriginRequest == nil {
 			result.OriginRequest = &cloudflare.OriginRequestConfig{}
 		}
-		result.OriginRequest.HTTPHostHeader = exposure.HTTPHostHeader
+		return result.OriginRequest
+	}
+
+	if exposure.HTTPHostHeader != nil {
+		originRequest().HTTPHostHeader = exposure.HTTPHostHeader
 	}
 
 	if strings.HasPrefix(exposure.ServiceTarget, "https://") {
-		if result.OriginRequest == nil {
-			result.OriginRequest = &cloudflare.OriginRequestConfig{}
-		}
-		result.OriginRequest.OriginServerName = exposure.OriginServerName
+		originRequest().OriginServerName = exposure.OriginServerName
 		if exposure.ProxySSLVerifyEnabled == nil {
-			result.OriginRequest.NoTLSVerify = ptr.To(true)
+			originRequest().NoTLSVerify = ptr.To(true)
 		} else {
-			result.OriginRequest.NoTLSVerify = ptr.To(!*exposure.ProxySSLVerifyEnabled)
+			originRequest().NoTLSVerify = ptr.To(!*exposure.ProxySSLVerifyEnabled)
 		}
+	}
+
+	// direct no-tls-verify control takes precedence over the legacy
+	// proxy-ssl-verify derived value above
+	if exposure.NoTLSVerify != nil {
+		originRequest().NoTLSVerify = exposure.NoTLSVerify
+	}
+
+	if exposure.ConnectTimeout != nil {
+		originRequest().ConnectTimeout = &cloudflare.TunnelDuration{Duration: *exposure.ConnectTimeout}
+	}
+	if exposure.TLSTimeout != nil {
+		originRequest().TLSTimeout = &cloudflare.TunnelDuration{Duration: *exposure.TLSTimeout}
+	}
+	if exposure.TCPKeepAlive != nil {
+		originRequest().TCPKeepAlive = &cloudflare.TunnelDuration{Duration: *exposure.TCPKeepAlive}
+	}
+	if exposure.KeepAliveTimeout != nil {
+		originRequest().KeepAliveTimeout = &cloudflare.TunnelDuration{Duration: *exposure.KeepAliveTimeout}
+	}
+	if exposure.NoHappyEyeballs != nil {
+		originRequest().NoHappyEyeballs = exposure.NoHappyEyeballs
+	}
+	if exposure.KeepAliveConnections != nil {
+		originRequest().KeepAliveConnections = exposure.KeepAliveConnections
+	}
+	if exposure.DisableChunkedEncoding != nil {
+		originRequest().DisableChunkedEncoding = exposure.DisableChunkedEncoding
+	}
+	if exposure.HTTP2Origin != nil {
+		originRequest().Http2Origin = exposure.HTTP2Origin
 	}
 
 	return &result, nil

--- a/pkg/cloudflare-controller/transform_test.go
+++ b/pkg/cloudflare-controller/transform_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
 	"github.com/cloudflare/cloudflare-go"
@@ -232,6 +233,80 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
 					NoTLSVerify: ptr.To(false),
+				},
+			},
+		}, {
+			name: "all origin request fields set on http target",
+			args: args{
+				ctx: context.Background(),
+				exposure: exposure.Exposure{
+					Hostname:               "ingress.example.com",
+					ServiceTarget:          "http://10.0.0.1:80",
+					PathPrefix:             "/",
+					IsDeleted:              false,
+					ConnectTimeout:         ptr.To(30 * time.Second),
+					TLSTimeout:             ptr.To(10 * time.Second),
+					TCPKeepAlive:           ptr.To(time.Minute),
+					NoHappyEyeballs:        ptr.To(true),
+					KeepAliveConnections:   ptr.To(100),
+					KeepAliveTimeout:       ptr.To(90 * time.Second),
+					DisableChunkedEncoding: ptr.To(true),
+					HTTP2Origin:            ptr.To(true),
+				},
+			},
+			want: &cloudflare.UnvalidatedIngressRule{
+				Hostname: "ingress.example.com",
+				Path:     "/",
+				Service:  "http://10.0.0.1:80",
+				OriginRequest: &cloudflare.OriginRequestConfig{
+					ConnectTimeout:         &cloudflare.TunnelDuration{Duration: 30 * time.Second},
+					TLSTimeout:             &cloudflare.TunnelDuration{Duration: 10 * time.Second},
+					TCPKeepAlive:           &cloudflare.TunnelDuration{Duration: time.Minute},
+					NoHappyEyeballs:        ptr.To(true),
+					KeepAliveConnections:   ptr.To(100),
+					KeepAliveTimeout:       &cloudflare.TunnelDuration{Duration: 90 * time.Second},
+					DisableChunkedEncoding: ptr.To(true),
+					Http2Origin:            ptr.To(true),
+				},
+			},
+		}, {
+			name: "direct no-tls-verify overrides https default",
+			args: args{
+				ctx: context.Background(),
+				exposure: exposure.Exposure{
+					Hostname:      "ingress.example.com",
+					ServiceTarget: "https://10.0.0.1:443",
+					PathPrefix:    "/",
+					IsDeleted:     false,
+					NoTLSVerify:   ptr.To(false),
+				},
+			},
+			want: &cloudflare.UnvalidatedIngressRule{
+				Hostname: "ingress.example.com",
+				Path:     "/",
+				Service:  "https://10.0.0.1:443",
+				OriginRequest: &cloudflare.OriginRequestConfig{
+					NoTLSVerify: ptr.To(false),
+				},
+			},
+		}, {
+			name: "no-tls-verify applies to http target as well",
+			args: args{
+				ctx: context.Background(),
+				exposure: exposure.Exposure{
+					Hostname:      "ingress.example.com",
+					ServiceTarget: "http://10.0.0.1:80",
+					PathPrefix:    "/",
+					IsDeleted:     false,
+					NoTLSVerify:   ptr.To(true),
+				},
+			},
+			want: &cloudflare.UnvalidatedIngressRule{
+				Hostname: "ingress.example.com",
+				Path:     "/",
+				Service:  "http://10.0.0.1:80",
+				OriginRequest: &cloudflare.OriginRequestConfig{
+					NoTLSVerify: ptr.To(true),
 				},
 			},
 		},

--- a/pkg/cloudflare-controller/transform_test.go
+++ b/pkg/cloudflare-controller/transform_test.go
@@ -251,7 +251,6 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 					KeepAliveConnections:   ptr.To(100),
 					KeepAliveTimeout:       ptr.To(90 * time.Second),
 					DisableChunkedEncoding: ptr.To(true),
-					HTTP2Origin:            ptr.To(true),
 				},
 			},
 			want: &cloudflare.UnvalidatedIngressRule{
@@ -266,11 +265,10 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 					KeepAliveConnections:   ptr.To(100),
 					KeepAliveTimeout:       &cloudflare.TunnelDuration{Duration: 90 * time.Second},
 					DisableChunkedEncoding: ptr.To(true),
-					Http2Origin:            ptr.To(true),
 				},
 			},
 		}, {
-			name: "direct no-tls-verify overrides https default",
+			name: "direct no-tls-verify and http2-origin on https target",
 			args: args{
 				ctx: context.Background(),
 				exposure: exposure.Exposure{
@@ -279,6 +277,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 					PathPrefix:    "/",
 					IsDeleted:     false,
 					NoTLSVerify:   ptr.To(false),
+					HTTP2Origin:   ptr.To(true),
 				},
 			},
 			want: &cloudflare.UnvalidatedIngressRule{
@@ -287,6 +286,7 @@ func Test_fromExposureToCloudflareIngress(t *testing.T) {
 				Service:  "https://10.0.0.1:443",
 				OriginRequest: &cloudflare.OriginRequestConfig{
 					NoTLSVerify: ptr.To(false),
+					Http2Origin: ptr.To(true),
 				},
 			},
 		}, {

--- a/pkg/controller/origin_request_test.go
+++ b/pkg/controller/origin_request_test.go
@@ -11,6 +11,7 @@ import (
 func Test_parseOriginRequestSettings(t *testing.T) {
 	tests := []struct {
 		name        string
+		scheme      string
 		annotations map[string]string
 		want        originRequestSettings
 		wantErr     bool
@@ -21,7 +22,8 @@ func Test_parseOriginRequestSettings(t *testing.T) {
 			want:        originRequestSettings{},
 		},
 		{
-			name: "all fields set",
+			name:   "all fields set",
+			scheme: "https",
 			annotations: map[string]string{
 				AnnotationConnectTimeout:         "30s",
 				AnnotationTLSTimeout:             "10s",
@@ -81,11 +83,46 @@ func Test_parseOriginRequestSettings(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "zero integer rejected",
+			name: "zero keepalive connections disables the idle pool",
 			annotations: map[string]string{
 				AnnotationKeepAliveConnections: "0",
 			},
+			want: originRequestSettings{
+				KeepAliveConnections: ptr.To(0),
+			},
+		},
+		{
+			name: "negative integer rejected",
+			annotations: map[string]string{
+				AnnotationKeepAliveConnections: "-1",
+			},
 			wantErr: true,
+		},
+		{
+			name: "http2-origin requires https backend",
+			annotations: map[string]string{
+				AnnotationHTTP2Origin: "true",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "http2-origin allowed on https backend",
+			scheme: "https",
+			annotations: map[string]string{
+				AnnotationHTTP2Origin: "true",
+			},
+			want: originRequestSettings{
+				HTTP2Origin: ptr.To(true),
+			},
+		},
+		{
+			name: "explicit http2-origin false allowed on http backend",
+			annotations: map[string]string{
+				AnnotationHTTP2Origin: "false",
+			},
+			want: originRequestSettings{
+				HTTP2Origin: ptr.To(false),
+			},
 		},
 		{
 			name: "no-tls-verify conflicts with proxy-ssl-verify",
@@ -98,7 +135,11 @@ func Test_parseOriginRequestSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseOriginRequestSettings(tt.annotations)
+			scheme := tt.scheme
+			if scheme == "" {
+				scheme = "http"
+			}
+			got, err := parseOriginRequestSettings(tt.annotations, scheme)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseOriginRequestSettings() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/origin_request_test.go
+++ b/pkg/controller/origin_request_test.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/utils/ptr"
+)
+
+func Test_parseOriginRequestSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        originRequestSettings
+		wantErr     bool
+	}{
+		{
+			name:        "no annotations leaves everything nil",
+			annotations: map[string]string{},
+			want:        originRequestSettings{},
+		},
+		{
+			name: "all fields set",
+			annotations: map[string]string{
+				AnnotationConnectTimeout:         "30s",
+				AnnotationTLSTimeout:             "10s",
+				AnnotationTCPKeepAlive:           "1m",
+				AnnotationNoHappyEyeballs:        "true",
+				AnnotationKeepAliveConnections:   "100",
+				AnnotationKeepAliveTimeout:       "90s",
+				AnnotationNoTLSVerify:            "false",
+				AnnotationDisableChunkedEncoding: "true",
+				AnnotationHTTP2Origin:            "true",
+			},
+			want: originRequestSettings{
+				ConnectTimeout:         ptr.To(30 * time.Second),
+				TLSTimeout:             ptr.To(10 * time.Second),
+				TCPKeepAlive:           ptr.To(time.Minute),
+				NoHappyEyeballs:        ptr.To(true),
+				KeepAliveConnections:   ptr.To(100),
+				KeepAliveTimeout:       ptr.To(90 * time.Second),
+				NoTLSVerify:            ptr.To(false),
+				DisableChunkedEncoding: ptr.To(true),
+				HTTP2Origin:            ptr.To(true),
+			},
+		},
+		{
+			name: "invalid bool value",
+			annotations: map[string]string{
+				AnnotationHTTP2Origin: "yes",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid duration value",
+			annotations: map[string]string{
+				AnnotationConnectTimeout: "30",
+			},
+			wantErr: true,
+		},
+		{
+			name: "sub second duration rejected",
+			annotations: map[string]string{
+				AnnotationConnectTimeout: "1500ms",
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative duration rejected",
+			annotations: map[string]string{
+				AnnotationTLSTimeout: "-10s",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid integer value",
+			annotations: map[string]string{
+				AnnotationKeepAliveConnections: "many",
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero integer rejected",
+			annotations: map[string]string{
+				AnnotationKeepAliveConnections: "0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "no-tls-verify conflicts with proxy-ssl-verify",
+			annotations: map[string]string{
+				AnnotationNoTLSVerify:    "true",
+				AnnotationProxySSLVerify: "off",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseOriginRequestSettings(tt.annotations)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOriginRequestSettings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseOriginRequestSettings() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -86,7 +86,7 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			}
 		}
 
-		originRequest, err := parseOriginRequestSettings(ingress.Annotations)
+		originRequest, err := parseOriginRequestSettings(ingress.Annotations, scheme)
 		if err != nil {
 			return nil, err
 		}
@@ -218,7 +218,7 @@ type originRequestSettings struct {
 	HTTP2Origin            *bool
 }
 
-func parseOriginRequestSettings(annotations map[string]string) (originRequestSettings, error) {
+func parseOriginRequestSettings(annotations map[string]string, scheme string) (originRequestSettings, error) {
 	settings := originRequestSettings{}
 	var err error
 
@@ -257,6 +257,15 @@ func parseOriginRequestSettings(annotations map[string]string) (originRequestSet
 				AnnotationNoTLSVerify, AnnotationProxySSLVerify,
 			)
 		}
+	}
+
+	// HTTP/2 to the origin needs TLS, cloudflared silently keeps HTTP/1.1 for
+	// cleartext origins, reject the combination instead of not taking effect
+	if settings.HTTP2Origin != nil && *settings.HTTP2Origin && scheme != "https" {
+		return settings, errors.Errorf(
+			"annotation %s requires %s: https, HTTP/2 to the origin only works over TLS",
+			AnnotationHTTP2Origin, AnnotationBackendProtocol,
+		)
 	}
 
 	return settings, nil
@@ -298,9 +307,11 @@ func parseIntAnnotation(annotations map[string]string, key string) (*int, error)
 	if !ok {
 		return nil, nil
 	}
+	// zero is meaningful, for keepalive-connections it disables the idle
+	// connection pool entirely
 	parsed, err := strconv.Atoi(value)
-	if err != nil || parsed <= 0 {
-		return nil, errors.Errorf("invalid value %q for annotation %s, expect a positive integer", value, key)
+	if err != nil || parsed < 0 {
+		return nil, errors.Errorf("invalid value %q for annotation %s, expect a non negative integer", value, key)
 	}
 	return ptr.To(parsed), nil
 }

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -84,6 +86,11 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			}
 		}
 
+		originRequest, err := parseOriginRequestSettings(ingress.Annotations)
+		if err != nil {
+			return nil, err
+		}
+
 		var proxySSLVerifyEnabled *bool
 
 		if proxySSLVerify, ok := getAnnotation(ingress.Annotations, AnnotationProxySSLVerify); ok {
@@ -143,14 +150,23 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 			}
 
 			result = append(result, exposure.Exposure{
-				Hostname:              hostname,
-				ServiceTarget:         fmt.Sprintf("%s://%s:%d", scheme, host, port),
-				PathPrefix:            path.Path,
-				IsDeleted:             isDeleted,
-				ProxySSLVerifyEnabled: proxySSLVerifyEnabled,
-				HTTPHostHeader:        httpHostHeader,
-				OriginServerName:      originServerName,
-				DisableDNSManagement:  disableDNSManagement,
+				Hostname:               hostname,
+				ServiceTarget:          fmt.Sprintf("%s://%s:%d", scheme, host, port),
+				PathPrefix:             path.Path,
+				IsDeleted:              isDeleted,
+				ProxySSLVerifyEnabled:  proxySSLVerifyEnabled,
+				HTTPHostHeader:         httpHostHeader,
+				OriginServerName:       originServerName,
+				DisableDNSManagement:   disableDNSManagement,
+				ConnectTimeout:         originRequest.ConnectTimeout,
+				TLSTimeout:             originRequest.TLSTimeout,
+				TCPKeepAlive:           originRequest.TCPKeepAlive,
+				NoHappyEyeballs:        originRequest.NoHappyEyeballs,
+				KeepAliveConnections:   originRequest.KeepAliveConnections,
+				KeepAliveTimeout:       originRequest.KeepAliveTimeout,
+				NoTLSVerify:            originRequest.NoTLSVerify,
+				DisableChunkedEncoding: originRequest.DisableChunkedEncoding,
+				HTTP2Origin:            originRequest.HTTP2Origin,
 			})
 		}
 	}
@@ -186,4 +202,105 @@ func getPortWithName(ports []v1.ServicePort, portName string) (bool, int32) {
 func getAnnotation(annotations map[string]string, key string) (string, bool) {
 	value, ok := annotations[key]
 	return value, ok
+}
+
+// originRequestSettings carries the parsed originRequest related annotations,
+// they apply to every rule generated from the ingress.
+type originRequestSettings struct {
+	ConnectTimeout         *time.Duration
+	TLSTimeout             *time.Duration
+	TCPKeepAlive           *time.Duration
+	NoHappyEyeballs        *bool
+	KeepAliveConnections   *int
+	KeepAliveTimeout       *time.Duration
+	NoTLSVerify            *bool
+	DisableChunkedEncoding *bool
+	HTTP2Origin            *bool
+}
+
+func parseOriginRequestSettings(annotations map[string]string) (originRequestSettings, error) {
+	settings := originRequestSettings{}
+	var err error
+
+	if settings.ConnectTimeout, err = parseDurationAnnotation(annotations, AnnotationConnectTimeout); err != nil {
+		return settings, err
+	}
+	if settings.TLSTimeout, err = parseDurationAnnotation(annotations, AnnotationTLSTimeout); err != nil {
+		return settings, err
+	}
+	if settings.TCPKeepAlive, err = parseDurationAnnotation(annotations, AnnotationTCPKeepAlive); err != nil {
+		return settings, err
+	}
+	if settings.NoHappyEyeballs, err = parseBoolAnnotation(annotations, AnnotationNoHappyEyeballs); err != nil {
+		return settings, err
+	}
+	if settings.KeepAliveConnections, err = parseIntAnnotation(annotations, AnnotationKeepAliveConnections); err != nil {
+		return settings, err
+	}
+	if settings.KeepAliveTimeout, err = parseDurationAnnotation(annotations, AnnotationKeepAliveTimeout); err != nil {
+		return settings, err
+	}
+	if settings.NoTLSVerify, err = parseBoolAnnotation(annotations, AnnotationNoTLSVerify); err != nil {
+		return settings, err
+	}
+	if settings.DisableChunkedEncoding, err = parseBoolAnnotation(annotations, AnnotationDisableChunkedEncoding); err != nil {
+		return settings, err
+	}
+	if settings.HTTP2Origin, err = parseBoolAnnotation(annotations, AnnotationHTTP2Origin); err != nil {
+		return settings, err
+	}
+
+	if settings.NoTLSVerify != nil {
+		if _, ok := getAnnotation(annotations, AnnotationProxySSLVerify); ok {
+			return settings, errors.Errorf(
+				"annotations %s and %s are mutually exclusive, they express the same setting inverted",
+				AnnotationNoTLSVerify, AnnotationProxySSLVerify,
+			)
+		}
+	}
+
+	return settings, nil
+}
+
+func parseBoolAnnotation(annotations map[string]string, key string) (*bool, error) {
+	value, ok := getAnnotation(annotations, key)
+	if !ok {
+		return nil, nil
+	}
+	switch value {
+	case "true":
+		return ptr.To(true), nil
+	case "false":
+		return ptr.To(false), nil
+	default:
+		return nil, errors.Errorf("invalid value %q for annotation %s, available values: \"true\" or \"false\"", value, key)
+	}
+}
+
+func parseDurationAnnotation(annotations map[string]string, key string) (*time.Duration, error) {
+	value, ok := getAnnotation(annotations, key)
+	if !ok {
+		return nil, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return nil, errors.Errorf("invalid value %q for annotation %s, expect a Go duration string like \"30s\"", value, key)
+	}
+	// the Cloudflare API serializes originRequest durations in whole seconds
+	if duration <= 0 || duration != duration.Truncate(time.Second) {
+		return nil, errors.Errorf("invalid value %q for annotation %s, expect a positive duration in whole seconds", value, key)
+	}
+	return ptr.To(duration), nil
+}
+
+func parseIntAnnotation(annotations map[string]string, key string) (*int, error) {
+	value, ok := getAnnotation(annotations, key)
+	if !ok {
+		return nil, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return nil, errors.Errorf("invalid value %q for annotation %s, expect a positive integer", value, key)
+	}
+	return ptr.To(parsed), nil
 }

--- a/pkg/controller/well_known_annotations.go
+++ b/pkg/controller/well_known_annotations.go
@@ -21,3 +21,43 @@ const AnnotationOriginServerName = "cloudflare-tunnel-ingress-controller.strrl.d
 const AnnotationDisableDNSManagement = "cloudflare-tunnel-ingress-controller.strrl.dev/disable-dns-management"
 const AnnotationDisableDNSManagementTrue = "true"
 const AnnotationDisableDNSManagementFalse = "false"
+
+// The annotations below map to cloudflared originRequest settings applied to
+// every rule generated from the ingress. See
+// https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/origin-parameters/
+
+// AnnotationConnectTimeout is the timeout for establishing a new TCP connection to the origin,
+// as a Go duration string in whole seconds, eg. "30s".
+const AnnotationConnectTimeout = "cloudflare-tunnel-ingress-controller.strrl.dev/connect-timeout"
+
+// AnnotationTLSTimeout is the timeout for completing a TLS handshake with the origin,
+// as a Go duration string in whole seconds, eg. "10s".
+const AnnotationTLSTimeout = "cloudflare-tunnel-ingress-controller.strrl.dev/tls-timeout"
+
+// AnnotationTCPKeepAlive is the TCP keepalive interval for connections to the origin,
+// as a Go duration string in whole seconds, eg. "30s".
+const AnnotationTCPKeepAlive = "cloudflare-tunnel-ingress-controller.strrl.dev/tcp-keepalive"
+
+// AnnotationNoHappyEyeballs disables the IPv4/IPv6 fallback when connecting to the origin,
+// available values: "true" or "false".
+const AnnotationNoHappyEyeballs = "cloudflare-tunnel-ingress-controller.strrl.dev/no-happy-eyeballs"
+
+// AnnotationKeepAliveConnections is the maximum keepalive connection pool size towards the origin,
+// as an integer, eg. "100".
+const AnnotationKeepAliveConnections = "cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-connections"
+
+// AnnotationKeepAliveTimeout is the timeout for closing idle connections to the origin,
+// as a Go duration string in whole seconds, eg. "90s".
+const AnnotationKeepAliveTimeout = "cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-timeout"
+
+// AnnotationNoTLSVerify disables TLS certificate verification of the origin, available
+// values: "true" or "false". Mutually exclusive with proxy-ssl-verify, which expresses
+// the same setting inverted.
+const AnnotationNoTLSVerify = "cloudflare-tunnel-ingress-controller.strrl.dev/no-tls-verify"
+
+// AnnotationDisableChunkedEncoding disables chunked transfer encoding towards the origin,
+// useful for WSGI servers, available values: "true" or "false".
+const AnnotationDisableChunkedEncoding = "cloudflare-tunnel-ingress-controller.strrl.dev/disable-chunked-encoding"
+
+// AnnotationHTTP2Origin connects to the origin with HTTP/2, available values: "true" or "false".
+const AnnotationHTTP2Origin = "cloudflare-tunnel-ingress-controller.strrl.dev/http2-origin"

--- a/pkg/exposure/exposure.go
+++ b/pkg/exposure/exposure.go
@@ -1,5 +1,7 @@
 package exposure
 
+import "time"
+
 // Exposure is the minimal information for exposing a service.
 type Exposure struct {
 	// Hostname is the domain name to expose the service, eg. hello.strrl.dev
@@ -21,6 +23,29 @@ type Exposure struct {
 	// tunnel ingress rule. DNS can then be delegated to an external system, e.g.
 	// external-dns or a Cloudflare Load Balancer targeting the tunnel directly.
 	DisableDNSManagement bool
+
+	// The fields below map to cloudflared originRequest settings, nil means
+	// the cloudflared default applies.
+
+	// ConnectTimeout is the timeout for establishing a new TCP connection to the origin.
+	ConnectTimeout *time.Duration
+	// TLSTimeout is the timeout for completing a TLS handshake with the origin.
+	TLSTimeout *time.Duration
+	// TCPKeepAlive is the TCP keepalive interval for connections to the origin.
+	TCPKeepAlive *time.Duration
+	// NoHappyEyeballs disables the IPv4/IPv6 fallback when connecting to the origin.
+	NoHappyEyeballs *bool
+	// KeepAliveConnections is the maximum keepalive connection pool size towards the origin.
+	KeepAliveConnections *int
+	// KeepAliveTimeout is the timeout for closing idle connections to the origin.
+	KeepAliveTimeout *time.Duration
+	// NoTLSVerify disables TLS certificate verification of the origin, it takes
+	// precedence over ProxySSLVerifyEnabled when set.
+	NoTLSVerify *bool
+	// DisableChunkedEncoding disables chunked transfer encoding towards the origin.
+	DisableChunkedEncoding *bool
+	// HTTP2Origin connects to the origin with HTTP/2.
+	HTTP2Origin *bool
 }
 
 // Active returns the exposures that are not marked as deleted, preserving order.

--- a/test/e2e/features/origin-request.feature
+++ b/test/e2e/features/origin-request.feature
@@ -1,0 +1,10 @@
+Feature: Origin request settings
+  Ingress annotations map to cloudflared originRequest settings on the
+  generated tunnel ingress rule. The scenario verifies the wiring end to end
+  by reading the tunnel configuration back from the Cloudflare API; per field
+  parsing and mapping are covered by unit tests on both transforms.
+
+  Scenario: annotations are applied to the tunnel ingress rule
+    Given an http echo service "echo-origin" replying "origin-request-e2e" is deployed
+    And an ingress with origin request annotations exposes "echo-origin" at a generated hostname
+    Then the tunnel ingress rule eventually carries the expected origin request settings

--- a/test/e2e/origin_request_steps_test.go
+++ b/test/e2e/origin_request_steps_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/cucumber/godog"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/utils/ptr"
 )
 
 // the annotations the scenario applies, a representative subset proving the
@@ -17,7 +18,7 @@ import (
 var originRequestTestAnnotations = map[string]string{
 	"cloudflare-tunnel-ingress-controller.strrl.dev/connect-timeout":          "31s",
 	"cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-connections":    "7",
-	"cloudflare-tunnel-ingress-controller.strrl.dev/http2-origin":             "true",
+	"cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-timeout":        "77s",
 	"cloudflare-tunnel-ingress-controller.strrl.dev/disable-chunked-encoding": "true",
 }
 
@@ -50,18 +51,21 @@ func theTunnelRuleCarriesOriginRequestSettings(ctx context.Context) error {
 	}
 	rc := cloudflare.ResourceIdentifier(os.Getenv("CLOUDFLARE_ACCOUNT_ID"))
 
-	tunnels, _, err := api.ListTunnels(context.Background(), rc, cloudflare.TunnelListParams{
-		Name: os.Getenv("CLOUDFLARE_TUNNEL_NAME"),
-	})
-	if err != nil {
-		return fmt.Errorf("list tunnels: %w", err)
-	}
-	if len(tunnels) == 0 {
-		return fmt.Errorf("tunnel %s not found", os.Getenv("CLOUDFLARE_TUNNEL_NAME"))
-	}
-	tunnelID := tunnels[0].ID
-
+	// tunnel discovery lives inside the retry loop so transient API failures
+	// do not abort the scenario
 	return waitFor("tunnel rule carries origin request settings", 5*time.Minute, 10*time.Second, func() error {
+		tunnels, _, err := api.ListTunnels(context.Background(), rc, cloudflare.TunnelListParams{
+			Name:      os.Getenv("CLOUDFLARE_TUNNEL_NAME"),
+			IsDeleted: ptr.To(false),
+		})
+		if err != nil {
+			return fmt.Errorf("list tunnels: %w", err)
+		}
+		if len(tunnels) == 0 {
+			return fmt.Errorf("tunnel %s not found", os.Getenv("CLOUDFLARE_TUNNEL_NAME"))
+		}
+		tunnelID := tunnels[0].ID
+
 		configuration, err := api.GetTunnelConfiguration(context.Background(), rc, tunnelID)
 		if err != nil {
 			return fmt.Errorf("get tunnel configuration: %w", err)
@@ -81,8 +85,8 @@ func theTunnelRuleCarriesOriginRequestSettings(ctx context.Context) error {
 			if origin.KeepAliveConnections == nil || *origin.KeepAliveConnections != 7 {
 				return fmt.Errorf("rule for %s has keepAliveConnections %v, want 7", w.hostname, origin.KeepAliveConnections)
 			}
-			if origin.Http2Origin == nil || !*origin.Http2Origin {
-				return fmt.Errorf("rule for %s has http2Origin %v, want true", w.hostname, origin.Http2Origin)
+			if origin.KeepAliveTimeout == nil || origin.KeepAliveTimeout.Duration != 77*time.Second {
+				return fmt.Errorf("rule for %s has keepAliveTimeout %v, want 77s", w.hostname, origin.KeepAliveTimeout)
 			}
 			if origin.DisableChunkedEncoding == nil || !*origin.DisableChunkedEncoding {
 				return fmt.Errorf("rule for %s has disableChunkedEncoding %v, want true", w.hostname, origin.DisableChunkedEncoding)

--- a/test/e2e/origin_request_steps_test.go
+++ b/test/e2e/origin_request_steps_test.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/cucumber/godog"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// the annotations the scenario applies, a representative subset proving the
+// annotation to tunnel configuration wiring; the remaining fields share the
+// same code path and are covered by unit tests
+var originRequestTestAnnotations = map[string]string{
+	"cloudflare-tunnel-ingress-controller.strrl.dev/connect-timeout":          "31s",
+	"cloudflare-tunnel-ingress-controller.strrl.dev/keepalive-connections":    "7",
+	"cloudflare-tunnel-ingress-controller.strrl.dev/http2-origin":             "true",
+	"cloudflare-tunnel-ingress-controller.strrl.dev/disable-chunked-encoding": "true",
+}
+
+func registerOriginRequestSteps(ctx *godog.ScenarioContext) {
+	ctx.Step(`^an ingress with origin request annotations exposes "([^"]*)" at a generated hostname$`, anIngressWithOriginRequestAnnotationsExposes)
+	ctx.Step(`^the tunnel ingress rule eventually carries the expected origin request settings$`, theTunnelRuleCarriesOriginRequestSettings)
+}
+
+func anIngressWithOriginRequestAnnotationsExposes(ctx context.Context, serviceName string) error {
+	w := worldFromContext(ctx)
+
+	hostname, err := buildTestHostname("cf-origin", baseDomain)
+	if err != nil {
+		return err
+	}
+	w.hostname = hostname
+	_, _ = fmt.Fprintf(logOut, "using origin request hostname %s\n", hostname)
+
+	return createScenarioIngress(w, namespacedName{namespace: "default", name: "origin-request-via-cloudflare"}, originRequestTestAnnotations, []networkingv1.IngressRule{
+		serviceIngressRule(hostname, serviceName, 80),
+	})
+}
+
+func theTunnelRuleCarriesOriginRequestSettings(ctx context.Context) error {
+	w := worldFromContext(ctx)
+
+	api, err := newCloudflareAPI()
+	if err != nil {
+		return err
+	}
+	rc := cloudflare.ResourceIdentifier(os.Getenv("CLOUDFLARE_ACCOUNT_ID"))
+
+	tunnels, _, err := api.ListTunnels(context.Background(), rc, cloudflare.TunnelListParams{
+		Name: os.Getenv("CLOUDFLARE_TUNNEL_NAME"),
+	})
+	if err != nil {
+		return fmt.Errorf("list tunnels: %w", err)
+	}
+	if len(tunnels) == 0 {
+		return fmt.Errorf("tunnel %s not found", os.Getenv("CLOUDFLARE_TUNNEL_NAME"))
+	}
+	tunnelID := tunnels[0].ID
+
+	return waitFor("tunnel rule carries origin request settings", 5*time.Minute, 10*time.Second, func() error {
+		configuration, err := api.GetTunnelConfiguration(context.Background(), rc, tunnelID)
+		if err != nil {
+			return fmt.Errorf("get tunnel configuration: %w", err)
+		}
+
+		for _, rule := range configuration.Config.Ingress {
+			if rule.Hostname != w.hostname {
+				continue
+			}
+			origin := rule.OriginRequest
+			if origin == nil {
+				return fmt.Errorf("rule for %s has no originRequest yet", w.hostname)
+			}
+			if origin.ConnectTimeout == nil || origin.ConnectTimeout.Duration != 31*time.Second {
+				return fmt.Errorf("rule for %s has connectTimeout %v, want 31s", w.hostname, origin.ConnectTimeout)
+			}
+			if origin.KeepAliveConnections == nil || *origin.KeepAliveConnections != 7 {
+				return fmt.Errorf("rule for %s has keepAliveConnections %v, want 7", w.hostname, origin.KeepAliveConnections)
+			}
+			if origin.Http2Origin == nil || !*origin.Http2Origin {
+				return fmt.Errorf("rule for %s has http2Origin %v, want true", w.hostname, origin.Http2Origin)
+			}
+			if origin.DisableChunkedEncoding == nil || !*origin.DisableChunkedEncoding {
+				return fmt.Errorf("rule for %s has disableChunkedEncoding %v, want true", w.hostname, origin.DisableChunkedEncoding)
+			}
+			return nil
+		}
+		return fmt.Errorf("no tunnel rule for hostname %s yet", w.hostname)
+	})
+}

--- a/test/e2e/steps_test.go
+++ b/test/e2e/steps_test.go
@@ -100,6 +100,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^any other hostname under the wildcard eventually serves "([^"]*)"$`, theProbeHostnameServes)
 
 	registerUninstallCleanupSteps(ctx)
+	registerOriginRequestSteps(ctx)
 
 	ctx.Step(`^an ingress exposes "([^"]*)" at a generated hostname$`, anIngressExposesEchoService)
 	ctx.Step(`^the controller eventually creates the CNAME and ownership TXT records$`, theControllerCreatesDNSRecords)


### PR DESCRIPTION
## Problem

Only four originRequest settings are configurable today (backend-protocol, proxy-ssl-verify, http-host-header, origin-server-name). Users need per-ingress control over timeouts, keepalive, HTTP/2 origin and chunked encoding (#276, #11).

## Solution

Add nine annotations mapping to cloudflared `originRequest` fields (upstream reference: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/origin-parameters/), parsed with typed helpers and applied to every rule generated from the ingress. Omitted annotations keep cloudflared defaults.

## Major Changes

- annotations and parsing (`pkg/controller`)
  - new annotations: `connect-timeout`, `tls-timeout`, `tcp-keepalive`, `no-happy-eyeballs`, `keepalive-connections`, `keepalive-timeout`, `no-tls-verify`, `disable-chunked-encoding`, `http2-origin`
  - durations are Go duration strings validated to whole positive seconds (the Cloudflare API serializes them as seconds); invalid values fail the transform with an explanatory error
  - `no-tls-verify` is the direct control and is mutually exclusive with the legacy `proxy-ssl-verify`; when set it takes precedence over the https default
- mapping (`pkg/cloudflare-controller/transform.go`)
  - Exposure fields map onto `cloudflare.OriginRequestConfig`, nil fields stay untouched
- testing
  - table driven unit tests cover every field, invalid values and the precedence rule on both transforms
  - one e2e scenario proves the wiring: an annotated ingress, then the tunnel configuration is read back via the Cloudflare API and asserted, no edge traffic involved
- docs: origin request section in the ingress annotations reference

Deferred from the issue, with reasons: `bastion-mode` and `proxy-address`/`proxy-port`/`proxy-type` are cloudflared instance level settings rather than per rule; `ca-pool` needs a file mounted into the connector pod; `match-sni-to-host` does not exist in cloudflare-go v0.117.

Closes #276
Closes #11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tunnel origin TLS and connection behavior is derived per Ingress; invalid annotations fail the transform (Warning events), and `no-tls-verify` vs `proxy-ssl-verify` precedence affects HTTPS backends.
> 
> **Overview**
> **Per-ingress cloudflared `originRequest` tuning** is added via nine new annotations (timeouts, keepalive, `no-tls-verify`, chunked encoding, HTTP/2 origin, etc.), documented in the ingress reference and `CLAUDE.md`.
> 
> Ingress transform now **parses** those annotations with typed helpers (whole-second durations, bool/int validation), rejects **`no-tls-verify` together with `proxy-ssl-verify`**, and requires **`http2-origin: "true"` only when `backend-protocol` is `https`**. Parsed values are copied onto every `Exposure` rule from that Ingress.
> 
> The Cloudflare transform **refactors** origin settings into `fromExposureToOriginRequest`, maps the new `Exposure` fields onto `OriginRequestConfig`, and lets **`no-tls-verify` override** the legacy HTTPS default from `proxy-ssl-verify`.
> 
> Coverage includes unit tests on both transforms, a Godog e2e scenario that reads tunnel config from the Cloudflare API, and no change to the core reconcile path beyond richer `Exposure` → tunnel rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ab7c120d7a59231274c757dd240c923e9d4daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->