### PR TITLE
feat: add controller observability (health probes, metrics, events)

### DIFF
--- a/cmd/cloudflare-tunnel-ingress-controller/main.go
+++ b/cmd/cloudflare-tunnel-ingress-controller/main.go
@@ -20,8 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 type rootCmdFlags struct {
@@ -45,6 +47,8 @@ type rootCmdFlags struct {
 	clusterDomain               string
 	leaderElect                 bool
 	dnsCommentTemplate          string
+	metricsBindAddress          string
+	healthProbeBindAddress      string
 }
 
 func main() {
@@ -64,6 +68,8 @@ func main() {
 		cloudflaredReplicaCount:    1,
 		clusterDomain:              "cluster.local",
 		dnsCommentTemplate:         "managed by cloudflare-tunnel-ingress-controller, tunnel [{{.TunnelName}}]",
+		metricsBindAddress:         ":9090",
+		healthProbeBindAddress:     ":8081",
 	}
 
 	crlog.SetLogger(rootLogger.WithName("controller-runtime"))
@@ -89,6 +95,8 @@ func main() {
 			options.clusterDomain = viper.GetString("cluster-domain")
 			options.leaderElect = viper.GetBool("leader-elect")
 			options.dnsCommentTemplate = viper.GetString("dns-comment-template")
+			options.metricsBindAddress = viper.GetString("metrics-bind-address")
+			options.healthProbeBindAddress = viper.GetString("health-probe-bind-address")
 			controllerDeploymentName := viper.GetString("controller-deployment-name")
 
 			stdr.SetVerbosity(options.logLevel)
@@ -127,12 +135,27 @@ func main() {
 						},
 					},
 				},
+				Metrics: metricsserver.Options{
+					BindAddress: options.metricsBindAddress,
+				},
+				HealthProbeBindAddress:  options.healthProbeBindAddress,
 				LeaderElection:          options.leaderElect,
 				LeaderElectionID:        "cloudflare-tunnel-ingress-controller.strrl.dev",
 				LeaderElectionNamespace: options.namespace,
 			})
 			if err != nil {
 				logger.Error(err, "unable to set up manager")
+				os.Exit(1)
+			}
+
+			if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+				logger.Error(err, "unable to set up health check")
+				os.Exit(1)
+			}
+			// the tunnel client is already bootstrapped at this point, so the
+			// controller is ready once the manager can serve requests
+			if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+				logger.Error(err, "unable to set up ready check")
 				os.Exit(1)
 			}
 
@@ -231,6 +254,8 @@ func main() {
 	rootCommand.PersistentFlags().StringVar(&options.clusterDomain, "cluster-domain", options.clusterDomain, "kubernetes cluster domain, used to build service FQDN (should match kubelet --cluster-domain)")
 	rootCommand.PersistentFlags().BoolVar(&options.leaderElect, "leader-elect", options.leaderElect, "enable leader election for high availability")
 	rootCommand.PersistentFlags().String("controller-deployment-name", "", "name of the controller Deployment, set as owner of the connector resources so garbage collection removes them on uninstall")
+	rootCommand.PersistentFlags().StringVar(&options.metricsBindAddress, "metrics-bind-address", options.metricsBindAddress, "address for the metrics endpoint, set to 0 to disable")
+	rootCommand.PersistentFlags().StringVar(&options.healthProbeBindAddress, "health-probe-bind-address", options.healthProbeBindAddress, "address for the healthz/readyz endpoints, set to 0 to disable")
 	rootCommand.PersistentFlags().StringVar(&options.dnsCommentTemplate, "dns-comment-template", options.dnsCommentTemplate, "Go template for DNS record comments. Available variables: {{.TunnelName}}, {{.TunnelId}}, {{.Hostname}}. Set to empty string to disable. Note: Cloudflare limits comment length by plan (Free: 100, Pro/Biz/Ent: 500 chars). See https://developers.cloudflare.com/dns/manage-dns-records/reference/record-attributes/")
 
 	viper.AutomaticEnv()

--- a/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
             {{- end }}
             - --cloudflared-deployment-config=/etc/cloudflared-config/config.json
             - --controller-deployment-name={{ include "cloudflare-tunnel-ingress-controller.fullname" . }}
+            - --metrics-bind-address=:{{ .Values.metrics.port }}
+            - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
           env:
             - name: CLOUDFLARE_API_TOKEN
               valueFrom:
@@ -92,6 +94,25 @@ spec:
               value: {{ .Values.cloudflared.image.pullPolicy | quote }}
             - name: CLOUDFLARED_REPLICA_COUNT
               value: {{ .Values.cloudflared.replicaCount | quote }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.healthProbe.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
           volumeMounts:
             - name: cloudflared-config
               mountPath: /etc/cloudflared-config

--- a/helm/cloudflare-tunnel-ingress-controller/templates/metrics-service.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudflare-tunnel-ingress-controller.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/component: controller
+    {{- include "cloudflare-tunnel-ingress-controller.labels" . | nindent 4 }}
+  annotations:
+    {{- if not .Values.metrics.serviceMonitor.create }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.metrics.port | quote }}
+    {{- end }}
+spec:
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "cloudflare-tunnel-ingress-controller.selectorLabels" . | nindent 4 }}

--- a/helm/cloudflare-tunnel-ingress-controller/templates/metrics-service.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/metrics-service.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cloudflare-tunnel-ingress-controller.fullname" . }}-metrics
+  {{- /* keep the full name within the 63 character limit of Kubernetes names */}}
+  name: {{ printf "%s-metrics" (include "cloudflare-tunnel-ingress-controller.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
     app.kubernetes.io/component: controller
     {{- include "cloudflare-tunnel-ingress-controller.labels" . | nindent 4 }}

--- a/helm/cloudflare-tunnel-ingress-controller/templates/metrics-servicemonitor.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.metrics.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cloudflare-tunnel-ingress-controller.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel-ingress-controller.labels" . | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      {{- include "cloudflare-tunnel-ingress-controller.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ .Values.metrics.serviceMonitor.metricRelabelings }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{ .Values.metrics.serviceMonitor.relabelings }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/helm/cloudflare-tunnel-ingress-controller/values.yaml
+++ b/helm/cloudflare-tunnel-ingress-controller/values.yaml
@@ -96,6 +96,23 @@ clusterDomain: cluster.local
 leaderElection:
   enabled: false
 
+# Metrics endpoint of the controller itself. It serves the controller-runtime
+# built-in metrics (reconcile counts, workqueue depth, and so on) plus custom
+# metrics like cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds.
+metrics:
+  port: 9090
+  serviceMonitor:
+    create: false
+    interval: ""
+    scrapeTimeout: ""
+    metricRelabelings: []
+    relabelings: []
+    labels: {}
+
+# Health endpoint of the controller, used by liveness and readiness probes.
+healthProbe:
+  port: 8081
+
 cloudflared:
   image:
     repository: cloudflare/cloudflared

--- a/pkg/cloudflare-controller/tunnel-client.go
+++ b/pkg/cloudflare-controller/tunnel-client.go
@@ -7,8 +7,10 @@ import (
 	"slices"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
+	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/metrics"
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -98,6 +100,9 @@ func (t *TunnelClient) PutExposures(ctx context.Context, exposures []exposure.Ex
 	if err != nil {
 		return errors.Wrap(err, "update DNS CNAME record")
 	}
+
+	metrics.ManagedExposures.Set(float64(len(exposure.Active(exposures))))
+	metrics.LastSuccessfulSyncTimestamp.Set(float64(time.Now().Unix()))
 	return nil
 }
 
@@ -132,6 +137,7 @@ func (t *TunnelClient) updateTunnelIngressRules(ctx context.Context, exposures [
 
 	current, err := t.cfClient.GetTunnelConfiguration(ctx, cloudflare.ResourceIdentifier(t.accountId), t.tunnelId)
 	if err != nil {
+		metrics.CloudflareAPIErrors.WithLabelValues("get_tunnel_configuration").Inc()
 		return errors.Wrap(err, "get cloudflare tunnel config")
 	}
 
@@ -151,6 +157,7 @@ func (t *TunnelClient) updateTunnelIngressRules(ctx context.Context, exposures [
 	)
 
 	if err != nil {
+		metrics.CloudflareAPIErrors.WithLabelValues("update_tunnel_configuration").Inc()
 		return errors.Wrap(err, "update cloudflare tunnel config")
 	}
 	return nil
@@ -160,6 +167,7 @@ func (t *TunnelClient) updateDNSCNAMERecord(ctx context.Context, exposures []exp
 	t.logger.V(3).Info("list zones")
 	zones, err := t.cfClient.ListZones(ctx)
 	if err != nil {
+		metrics.CloudflareAPIErrors.WithLabelValues("list_zones").Inc()
 		return errors.Wrap(err, "list cloudflare zones")
 	}
 
@@ -203,6 +211,7 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 		Type: "CNAME",
 	})
 	if err != nil {
+		metrics.CloudflareAPIErrors.WithLabelValues("list_dns_records").Inc()
 		return errors.Wrapf(err, "list CNAME records for zone %s", zone.Name)
 	}
 
@@ -210,6 +219,7 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 		Type: "TXT",
 	})
 	if err != nil {
+		metrics.CloudflareAPIErrors.WithLabelValues("list_dns_records").Inc()
 		return errors.Wrapf(err, "list TXT records for zone %s", zone.Name)
 	}
 
@@ -244,8 +254,10 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 		}
 		_, err := t.cfClient.CreateDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), params)
 		if err != nil {
+			metrics.CloudflareAPIErrors.WithLabelValues("create_dns_record").Inc()
 			return errors.Wrapf(err, "create DNS record for zone %s, hostname %s", zone.Name, item.Hostname)
 		}
+		metrics.DNSRecordOperations.WithLabelValues("create", item.Type).Inc()
 	}
 
 	for _, item := range toUpdate {
@@ -264,8 +276,10 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 		}
 		_, err := t.cfClient.UpdateDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), params)
 		if err != nil {
+			metrics.CloudflareAPIErrors.WithLabelValues("update_dns_record").Inc()
 			return errors.Wrapf(err, "update DNS record for zone %s, hostname %s", zone.Name, item.OldRecord.Name)
 		}
+		metrics.DNSRecordOperations.WithLabelValues("update", item.Type).Inc()
 	}
 
 	// Migrate legacy comment-based records (separate from normal sync)
@@ -279,8 +293,10 @@ func (t *TunnelClient) updateDNSCNAMERecordForZone(ctx context.Context, exposure
 		t.logger.Info("delete DNS record", "id", item.OldRecord.ID, "type", item.OldRecord.Type, "hostname", item.OldRecord.Name, "content", item.OldRecord.Content)
 		err := t.cfClient.DeleteDNSRecord(ctx, cloudflare.ResourceIdentifier(zone.ID), item.OldRecord.ID)
 		if err != nil {
+			metrics.CloudflareAPIErrors.WithLabelValues("delete_dns_record").Inc()
 			return errors.Wrapf(err, "delete DNS record for zone %s, hostname %s", zone.Name, item.OldRecord.Name)
 		}
+		metrics.DNSRecordOperations.WithLabelValues("delete", item.OldRecord.Type).Inc()
 	}
 
 	return nil

--- a/pkg/controller/ingress-controller.go
+++ b/pkg/controller/ingress-controller.go
@@ -95,7 +95,11 @@ func (i *IngressController) Reconcile(ctx context.Context, request reconcile.Req
 
 	err = i.tunnelClient.PutExposures(ctx, allExposures)
 	if err != nil {
+		i.recorder.Event(&origin, v1.EventTypeWarning, EventReasonSyncFailed, err.Error())
 		return reconcile.Result{}, errors.Wrap(err, "put exposures")
+	}
+	if origin.DeletionTimestamp == nil {
+		i.recorder.Event(&origin, v1.EventTypeNormal, EventReasonSynced, "cloudflare tunnel config and DNS records are up to date")
 	}
 
 	if origin.DeletionTimestamp != nil {

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -20,6 +20,8 @@ const (
 	EventReasonTLSIgnored      = "TLSIgnored"
 	EventReasonRuleSkipped     = "RuleSkipped"
 	EventReasonTransformFailed = "TransformFailed"
+	EventReasonSyncFailed      = "CloudflareSyncFailed"
+	EventReasonSynced          = "CloudflareSynced"
 )
 
 func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient client.Client, recorder record.EventRecorder, ingress networkingv1.Ingress, clusterDomain string) ([]exposure.Exposure, error) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,55 @@
+// Package metrics holds the custom prometheus metrics of the controller.
+// All metrics are registered into the controller-runtime registry, so they
+// are served on the same /metrics endpoint as the built-in controller
+// metrics (reconcile counts, workqueue depth, and so on).
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const namespace = "cloudflare_tunnel_ingress_controller"
+
+var (
+	// LastSuccessfulSyncTimestamp is the unix time of the last time the
+	// controller pushed tunnel config and DNS records to Cloudflare with
+	// no error. Alert on this value getting old to catch config drift or
+	// a broken API token.
+	LastSuccessfulSyncTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "last_successful_sync_timestamp_seconds",
+		Help:      "Unix timestamp of the last successful sync to Cloudflare.",
+	})
+
+	// ManagedExposures is the number of active exposures (host and path
+	// pairs) the controller currently manages.
+	ManagedExposures = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "managed_exposures",
+		Help:      "Number of active exposures managed by the controller.",
+	})
+
+	// CloudflareAPIErrors counts failed Cloudflare API calls by operation.
+	CloudflareAPIErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "cloudflare_api_errors_total",
+		Help:      "Total number of failed Cloudflare API calls.",
+	}, []string{"operation"})
+
+	// DNSRecordOperations counts DNS record changes applied to Cloudflare.
+	DNSRecordOperations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "dns_record_operations_total",
+		Help:      "Total number of DNS record changes applied to Cloudflare.",
+	}, []string{"operation", "record_type"})
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(
+		LastSuccessfulSyncTimestamp,
+		ManagedExposures,
+		CloudflareAPIErrors,
+		DNSRecordOperations,
+	)
+}


### PR DESCRIPTION
## Problem

The controller itself has almost no observability. There are no healthz/readyz endpoints or probes, the controller-runtime metrics server is not exposed by the Helm chart, there are no business metrics for the Cloudflare sync, and sync failures are only visible in controller logs.

## Solution

Add health endpoints with Helm probes, expose the controller metrics endpoint, add a small set of business metrics, and emit Kubernetes Events for sync results.

## Major Changes

- Health endpoints
  - Manager now serves healthz/readyz (default :8081, configurable via --health-probe-bind-address), Helm deployment adds liveness/readiness probes.
- Controller metrics exposure
  - Metrics server bound to :9090 (configurable via --metrics-bind-address), new metrics Service and optional ServiceMonitor in the Helm chart, new metrics.* and healthProbe.* values.
- Business metrics (new pkg/metrics, registered on the controller-runtime registry)
  - last_successful_sync_timestamp_seconds, managed_exposures, cloudflare_api_errors_total{operation}, dns_record_operations_total{operation,record_type}.
- Events
  - PutExposures failure now emits a CloudflareSyncFailed warning event on the triggering ingress, success emits a CloudflareSynced normal event, so kubectl describe ingress shows sync results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only additions around controller-runtime health/metrics and metric counters; no change to tunnel or DNS reconciliation behavior beyond instrumentation and events.
> 
> **Overview**
> Adds **health and metrics endpoints** to the controller manager (defaults `:8081` for `/healthz` and `/readyz`, `:9090` for Prometheus), with CLI flags to bind or disable them. The Helm chart wires **liveness/readiness probes**, exposes a **metrics Service** (annotation-based scrape when no ServiceMonitor), and an optional **Prometheus Operator ServiceMonitor**.
> 
> Introduces **`pkg/metrics`** with gauges/counters for last successful Cloudflare sync, managed exposure count, API errors by operation, and DNS record operations; **`TunnelClient`** updates these on sync success and on Cloudflare API failures without changing reconciliation logic.
> 
> On reconcile, **`PutExposures`** failures and successes now emit **`CloudflareSyncFailed`** / **`CloudflareSynced`** Kubernetes Events on the triggering Ingress so sync status shows up in `kubectl describe`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93fc9645e508940b22faaceffe45921b4ca3cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->