### PR TITLE
feat: add Grafana dashboards for controller and per-hostname traffic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,10 @@ e2e: e2e-image
 .PHONY: setup-envtest
 setup-envtest:
 	bash ./hack/install-setup-envtest.sh
+
+# Compile the Grafana dashboards from jsonnet sources into plain JSON
+# files under mixin/dist. Requires the jsonnet binary.
+.PHONY: dashboards
+dashboards:
+	jsonnet mixin/dashboards/controller.jsonnet > mixin/dist/controller.json
+	jsonnet mixin/dashboards/cloudflared.jsonnet > mixin/dist/cloudflared.json

--- a/docs/src/content/docs/how-to/monitoring.md
+++ b/docs/src/content/docs/how-to/monitoring.md
@@ -84,6 +84,16 @@ kubectl get servicemonitor \
   -n cloudflare-tunnel-ingress-controller
 ```
 
+## Import the Grafana dashboards
+
+The repository ships two ready to import Grafana dashboards in the
+[`mixin/dist`](https://github.com/STRRL/cloudflare-tunnel-ingress-controller/tree/master/mixin/dist) directory:
+
+1. `controller.json` shows controller health: sync freshness, managed exposures, Cloudflare API errors, DNS record changes, and reconcile activity.
+2. `cloudflared.json` shows traffic per exposed hostname: request rate, status codes, latency percentiles, and traffic volume. These panels use the per hostname metrics from the default `ghcr.io/strrl/cloudflared` image.
+
+Import each file in Grafana with `Dashboards -> New -> Import` and select your Prometheus data source. Both metrics endpoints described above must be scraped for the panels to show data.
+
 ## Add cloudflared health probes
 
 The chart copies `cloudflared.probes.liveness`, `readiness`, and `startup` into the managed connector container as Kubernetes probe objects.

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -1,0 +1,34 @@
+# Grafana Dashboards
+
+Grafana dashboards for the controller and its managed cloudflared connectors,
+written in jsonnet.
+
+## Ready to import JSON
+
+The compiled dashboards live in `dist/`:
+
+- `dist/controller.json`: controller health. Sync freshness, managed
+  exposures, Cloudflare API errors, DNS record changes, reconcile activity,
+  and workqueue depth.
+- `dist/cloudflared.json`: per hostname traffic. Request rate, status codes,
+  latency percentiles, origin latency breakdown, proxy errors, and traffic
+  volume for every exposed hostname.
+
+Import them in Grafana with `Dashboards -> New -> Import`, then pick your
+Prometheus data source.
+
+The per hostname panels need the patched cloudflared image
+(`ghcr.io/strrl/cloudflared`), which is the chart default. See the
+[monitoring guide](https://tunnel.strrl.dev/how-to/monitoring/) for how to
+scrape both metrics endpoints.
+
+## Rebuild from source
+
+The jsonnet sources are in `dashboards/` with a small helper library in
+`lib/`. After changing them, rebuild the JSON files:
+
+```bash
+make dashboards
+```
+
+This requires the [jsonnet](https://jsonnet.org/) binary.

--- a/mixin/dashboards/cloudflared.jsonnet
+++ b/mixin/dashboards/cloudflared.jsonnet
@@ -1,0 +1,105 @@
+// Dashboard for the managed cloudflared connectors: per hostname traffic
+// from the patched image (ghcr.io/strrl/cloudflared) plus tunnel wide
+// request and error rates.
+local g = import '../lib/grafana.libsonnet';
+
+local hostFilter = 'host=~"$host"';
+
+local panels = [
+  g.stat(
+    'Request Rate',
+    [g.target('sum(rate(cloudflared_tunnel_host_requests_total{%s}[$__rate_interval]))' % hostFilter, 'req/s')],
+    { x: 0, y: 0, w: 6, h: 5 },
+    unit='reqps',
+  ),
+  g.stat(
+    'Error Rate (5xx)',
+    [g.target('sum(rate(cloudflared_tunnel_host_requests_total{%s, status=~"5.."}[$__rate_interval])) or vector(0)' % hostFilter, '5xx/s')],
+    { x: 6, y: 0, w: 6, h: 5 },
+    unit='reqps',
+    thresholds={
+      mode: 'absolute',
+      steps: [
+        { color: 'green', value: null },
+        { color: 'red', value: 0.1 },
+      ],
+    },
+  ),
+  g.stat(
+    'p99 Request Duration',
+    [g.target('histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_request_duration_seconds_bucket{%s}[$__rate_interval])))' % hostFilter, 'p99')],
+    { x: 12, y: 0, w: 6, h: 5 },
+    unit='s',
+  ),
+  g.stat(
+    'Connectors Up',
+    [g.target('count(up{job=~".*cloudflared.*"} == 1) or vector(0)', 'pods')],
+    { x: 18, y: 0, w: 6, h: 5 },
+  ),
+
+  g.timeseries(
+    'Request Rate by Host',
+    [g.target('sum by (host) (rate(cloudflared_tunnel_host_requests_total{%s}[$__rate_interval]))' % hostFilter, '{{host}}')],
+    { x: 0, y: 5, w: 12, h: 8 },
+    unit='reqps',
+  ),
+  g.timeseries(
+    'Responses by Status Class',
+    [g.target('sum by (status) (rate(cloudflared_tunnel_host_requests_total{%s}[$__rate_interval]))' % hostFilter, '{{status}}')],
+    { x: 12, y: 5, w: 12, h: 8 },
+    unit='reqps',
+  ),
+
+  g.timeseries(
+    'Request Duration by Host (p99)',
+    [g.target('histogram_quantile(0.99, sum by (host, le) (rate(cloudflared_tunnel_host_request_duration_seconds_bucket{%s}[$__rate_interval])))' % hostFilter, '{{host}}')],
+    { x: 0, y: 13, w: 12, h: 8 },
+    unit='s',
+  ),
+  g.timeseries(
+    'Origin Latency Breakdown (p99)',
+    [
+      g.target('histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_connect_duration_seconds_bucket{%s}[$__rate_interval])))' % hostFilter, 'connect'),
+      g.target('histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_header_duration_seconds_bucket{%s}[$__rate_interval])))' % hostFilter, 'first header'),
+      g.target('histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_response_duration_seconds_bucket{%s}[$__rate_interval])))' % hostFilter, 'full response'),
+    ],
+    { x: 12, y: 13, w: 12, h: 8 },
+    unit='s',
+  ),
+
+  g.timeseries(
+    'Proxy Errors by Host',
+    [g.target('sum by (host) (rate(cloudflared_tunnel_host_request_errors_total{%s}[$__rate_interval]))' % hostFilter, '{{host}}')],
+    { x: 0, y: 21, w: 12, h: 8 },
+    unit='ops',
+  ),
+  g.timeseries(
+    'Traffic Volume by Host',
+    [
+      g.target('sum by (host) (rate(cloudflared_tunnel_host_request_body_size_bytes_sum{%s}[$__rate_interval]))' % hostFilter, 'in {{host}}'),
+      g.target('sum by (host) (rate(cloudflared_tunnel_host_response_body_size_bytes_sum{%s}[$__rate_interval]))' % hostFilter, 'out {{host}}'),
+    ],
+    { x: 12, y: 21, w: 12, h: 8 },
+    unit='Bps',
+  ),
+
+  g.timeseries(
+    'Concurrent Requests per Tunnel',
+    [g.target('sum(cloudflared_tunnel_concurrent_requests_per_tunnel)', 'concurrent')],
+    { x: 0, y: 29, w: 12, h: 8 },
+  ),
+  g.timeseries(
+    'Active TCP Sessions',
+    [g.target('sum(cloudflared_tcp_active_sessions)', 'sessions')],
+    { x: 12, y: 29, w: 12, h: 8 },
+  ),
+];
+
+g.dashboard(
+  'Cloudflare Tunnel Traffic by Hostname',
+  'cf-tunnel-cloudflared-traffic',
+  panels,
+  variables=[
+    g.queryVariable('host', 'label_values(cloudflared_tunnel_host_requests_total, host)', multi=true),
+  ],
+)

--- a/mixin/dashboards/controller.jsonnet
+++ b/mixin/dashboards/controller.jsonnet
@@ -1,0 +1,92 @@
+// Dashboard for the controller itself: sync health, managed exposures,
+// Cloudflare API errors, DNS record changes, and reconcile activity.
+local g = import '../lib/grafana.libsonnet';
+
+local panels = [
+  g.stat(
+    'Managed Exposures',
+    [g.target('max(cloudflare_tunnel_ingress_controller_managed_exposures)', 'exposures')],
+    { x: 0, y: 0, w: 6, h: 5 },
+  ),
+  g.stat(
+    'Time Since Last Successful Sync',
+    [g.target('time() - max(cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds)', 'age')],
+    { x: 6, y: 0, w: 6, h: 5 },
+    unit='s',
+    thresholds={
+      mode: 'absolute',
+      steps: [
+        { color: 'green', value: null },
+        { color: 'yellow', value: 60 },
+        { color: 'red', value: 300 },
+      ],
+    },
+  ),
+  g.stat(
+    'Cloudflare API Errors (1h)',
+    [g.target('sum(increase(cloudflare_tunnel_ingress_controller_cloudflare_api_errors_total[1h])) or vector(0)', 'errors')],
+    { x: 12, y: 0, w: 6, h: 5 },
+    thresholds={
+      mode: 'absolute',
+      steps: [
+        { color: 'green', value: null },
+        { color: 'red', value: 1 },
+      ],
+    },
+  ),
+  g.stat(
+    'Controller Pods Up',
+    [g.target('count(up{job=~"$job"} == 1)', 'pods')],
+    { x: 18, y: 0, w: 6, h: 5 },
+  ),
+
+  g.timeseries(
+    'Cloudflare API Errors by Operation',
+    [g.target('sum by (operation) (rate(cloudflare_tunnel_ingress_controller_cloudflare_api_errors_total[$__rate_interval]))', '{{operation}}')],
+    { x: 0, y: 5, w: 12, h: 8 },
+    unit='ops',
+  ),
+  g.timeseries(
+    'DNS Record Operations',
+    [g.target('sum by (operation, record_type) (rate(cloudflare_tunnel_ingress_controller_dns_record_operations_total[$__rate_interval]))', '{{operation}} {{record_type}}')],
+    { x: 12, y: 5, w: 12, h: 8 },
+    unit='ops',
+  ),
+
+  g.timeseries(
+    'Reconcile Rate by Result',
+    [g.target('sum by (result) (rate(controller_runtime_reconcile_total{job=~"$job"}[$__rate_interval]))', '{{result}}')],
+    { x: 0, y: 13, w: 12, h: 8 },
+    unit='ops',
+  ),
+  g.timeseries(
+    'Reconcile Duration (p50 / p99)',
+    [
+      g.target('histogram_quantile(0.50, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket{job=~"$job"}[$__rate_interval])))', 'p50'),
+      g.target('histogram_quantile(0.99, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket{job=~"$job"}[$__rate_interval])))', 'p99'),
+    ],
+    { x: 12, y: 13, w: 12, h: 8 },
+    unit='s',
+  ),
+
+  g.timeseries(
+    'Workqueue Depth',
+    [g.target('sum by (name) (workqueue_depth{job=~"$job"})', '{{name}}')],
+    { x: 0, y: 21, w: 12, h: 8 },
+  ),
+  g.timeseries(
+    'Kubernetes API Requests by Status',
+    [g.target('sum by (code) (rate(rest_client_requests_total{job=~"$job"}[$__rate_interval]))', '{{code}}')],
+    { x: 12, y: 21, w: 12, h: 8 },
+    unit='reqps',
+  ),
+];
+
+g.dashboard(
+  'Cloudflare Tunnel Ingress Controller',
+  'cf-tunnel-ingress-controller',
+  panels,
+  variables=[
+    g.queryVariable('job', 'label_values(controller_runtime_reconcile_total, job)', multi=true),
+  ],
+)

--- a/mixin/dist/cloudflared.json
+++ b/mixin/dist/cloudflared.json
@@ -1,0 +1,613 @@
+{
+   "editable": true,
+   "graphTooltip": 1,
+   "panels": [
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "reqps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(cloudflared_tunnel_host_requests_total{host=~\"$host\"}[$__rate_interval]))",
+               "legendFormat": "req/s",
+               "refId": "A"
+            }
+         ],
+         "title": "Request Rate",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 0.10000000000000001
+                     }
+                  ]
+               },
+               "unit": "reqps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(cloudflared_tunnel_host_requests_total{host=~\"$host\", status=~\"5..\"}[$__rate_interval])) or vector(0)",
+               "legendFormat": "5xx/s",
+               "refId": "A"
+            }
+         ],
+         "title": "Error Rate (5xx)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_request_duration_seconds_bucket{host=~\"$host\"}[$__rate_interval])))",
+               "legendFormat": "p99",
+               "refId": "A"
+            }
+         ],
+         "title": "p99 Request Duration",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "count(up{job=~\".*cloudflared.*\"} == 1) or vector(0)",
+               "legendFormat": "pods",
+               "refId": "A"
+            }
+         ],
+         "title": "Connectors Up",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "reqps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (host) (rate(cloudflared_tunnel_host_requests_total{host=~\"$host\"}[$__rate_interval]))",
+               "legendFormat": "{{host}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Request Rate by Host",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "reqps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (status) (rate(cloudflared_tunnel_host_requests_total{host=~\"$host\"}[$__rate_interval]))",
+               "legendFormat": "{{status}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Responses by Status Class",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum by (host, le) (rate(cloudflared_tunnel_host_request_duration_seconds_bucket{host=~\"$host\"}[$__rate_interval])))",
+               "legendFormat": "{{host}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Request Duration by Host (p99)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_connect_duration_seconds_bucket{host=~\"$host\"}[$__rate_interval])))",
+               "legendFormat": "connect",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_header_duration_seconds_bucket{host=~\"$host\"}[$__rate_interval])))",
+               "legendFormat": "first header",
+               "refId": "B"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum by (le) (rate(cloudflared_tunnel_host_response_duration_seconds_bucket{host=~\"$host\"}[$__rate_interval])))",
+               "legendFormat": "full response",
+               "refId": "C"
+            }
+         ],
+         "title": "Origin Latency Breakdown (p99)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "ops"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (host) (rate(cloudflared_tunnel_host_request_errors_total{host=~\"$host\"}[$__rate_interval]))",
+               "legendFormat": "{{host}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Proxy Errors by Host",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "Bps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (host) (rate(cloudflared_tunnel_host_request_body_size_bytes_sum{host=~\"$host\"}[$__rate_interval]))",
+               "legendFormat": "in {{host}}",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (host) (rate(cloudflared_tunnel_host_response_body_size_bytes_sum{host=~\"$host\"}[$__rate_interval]))",
+               "legendFormat": "out {{host}}",
+               "refId": "B"
+            }
+         ],
+         "title": "Traffic Volume by Host",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cloudflared_tunnel_concurrent_requests_per_tunnel)",
+               "legendFormat": "concurrent",
+               "refId": "A"
+            }
+         ],
+         "title": "Concurrent Requests per Tunnel",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cloudflared_tcp_active_sessions)",
+               "legendFormat": "sessions",
+               "refId": "A"
+            }
+         ],
+         "title": "Active TCP Sessions",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "30s",
+   "schemaVersion": 39,
+   "tags": [
+      "cloudflare-tunnel-ingress-controller"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data source",
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "allValue": ".+",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": true,
+            "multi": true,
+            "name": "host",
+            "query": {
+               "query": "label_values(cloudflared_tunnel_host_requests_total, host)",
+               "refId": "var-host"
+            },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-6h",
+      "to": "now"
+   },
+   "timezone": "",
+   "title": "Cloudflare Tunnel Traffic by Hostname",
+   "uid": "cf-tunnel-cloudflared-traffic"
+}

--- a/mixin/dist/controller.json
+++ b/mixin/dist/controller.json
@@ -1,0 +1,520 @@
+{
+   "editable": true,
+   "graphTooltip": 1,
+   "panels": [
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "max(cloudflare_tunnel_ingress_controller_managed_exposures)",
+               "legendFormat": "exposures",
+               "refId": "A"
+            }
+         ],
+         "title": "Managed Exposures",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 60
+                     },
+                     {
+                        "color": "red",
+                        "value": 300
+                     }
+                  ]
+               },
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 6,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "time() - max(cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds)",
+               "legendFormat": "age",
+               "refId": "A"
+            }
+         ],
+         "title": "Time Since Last Successful Sync",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 1
+                     }
+                  ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(increase(cloudflare_tunnel_ingress_controller_cloudflare_api_errors_total[1h])) or vector(0)",
+               "legendFormat": "errors",
+               "refId": "A"
+            }
+         ],
+         "title": "Cloudflare API Errors (1h)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ]
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "count(up{job=~\"$job\"} == 1)",
+               "legendFormat": "pods",
+               "refId": "A"
+            }
+         ],
+         "title": "Controller Pods Up",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "ops"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (operation) (rate(cloudflare_tunnel_ingress_controller_cloudflare_api_errors_total[$__rate_interval]))",
+               "legendFormat": "{{operation}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Cloudflare API Errors by Operation",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "ops"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (operation, record_type) (rate(cloudflare_tunnel_ingress_controller_dns_record_operations_total[$__rate_interval]))",
+               "legendFormat": "{{operation}} {{record_type}}",
+               "refId": "A"
+            }
+         ],
+         "title": "DNS Record Operations",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "ops"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (result) (rate(controller_runtime_reconcile_total{job=~\"$job\"}[$__rate_interval]))",
+               "legendFormat": "{{result}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Reconcile Rate by Result",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.50, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+               "legendFormat": "p50",
+               "refId": "A"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket{job=~\"$job\"}[$__rate_interval])))",
+               "legendFormat": "p99",
+               "refId": "B"
+            }
+         ],
+         "title": "Reconcile Duration (p50 / p99)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (name) (workqueue_depth{job=~\"$job\"})",
+               "legendFormat": "{{name}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Workqueue Depth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "lineWidth": 1,
+                  "showPoints": "never"
+               },
+               "unit": "reqps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+         },
+         "options": {
+            "legend": {
+               "displayMode": "list",
+               "placement": "bottom"
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (code) (rate(rest_client_requests_total{job=~\"$job\"}[$__rate_interval]))",
+               "legendFormat": "{{code}}",
+               "refId": "A"
+            }
+         ],
+         "title": "Kubernetes API Requests by Status",
+         "type": "timeseries"
+      }
+   ],
+   "refresh": "30s",
+   "schemaVersion": 39,
+   "tags": [
+      "cloudflare-tunnel-ingress-controller"
+   ],
+   "templating": {
+      "list": [
+         {
+            "label": "Data source",
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+         },
+         {
+            "allValue": ".+",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
+            "includeAll": true,
+            "multi": true,
+            "name": "job",
+            "query": {
+               "query": "label_values(controller_runtime_reconcile_total, job)",
+               "refId": "var-job"
+            },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-6h",
+      "to": "now"
+   },
+   "timezone": "",
+   "title": "Cloudflare Tunnel Ingress Controller",
+   "uid": "cf-tunnel-ingress-controller"
+}

--- a/mixin/lib/grafana.libsonnet
+++ b/mixin/lib/grafana.libsonnet
@@ -1,0 +1,96 @@
+// Small helper library to build Grafana dashboard JSON.
+// It only covers the pieces this project needs: dashboards,
+// template variables, timeseries panels, and stat panels.
+{
+  local datasource = { type: 'prometheus', uid: '${datasource}' },
+
+  dashboard(title, uid, panels, variables=[]):: {
+    title: title,
+    uid: uid,
+    schemaVersion: 39,
+    editable: true,
+    graphTooltip: 1,
+    timezone: '',
+    refresh: '30s',
+    time: { from: 'now-6h', to: 'now' },
+    tags: ['cloudflare-tunnel-ingress-controller'],
+    templating: {
+      list: [
+        {
+          name: 'datasource',
+          label: 'Data source',
+          type: 'datasource',
+          query: 'prometheus',
+        },
+      ] + variables,
+    },
+    panels: panels,
+  },
+
+  // A template variable filled from a label of an existing metric.
+  queryVariable(name, query, multi=false):: {
+    name: name,
+    type: 'query',
+    datasource: datasource,
+    query: { query: query, refId: 'var-' + name },
+    refresh: 2,
+    sort: 1,
+    multi: multi,
+    includeAll: multi,
+    [if multi then 'allValue']: '.+',
+  },
+
+  target(expr, legend):: {
+    expr: expr,
+    legendFormat: legend,
+    datasource: datasource,
+  },
+
+  local withRefIds(targets) = std.mapWithIndex(
+    function(i, t) t { refId: std.char(std.codepoint('A') + i) },
+    targets,
+  ),
+
+  timeseries(title, targets, gridPos, unit='short'):: {
+    type: 'timeseries',
+    title: title,
+    datasource: datasource,
+    gridPos: gridPos,
+    fieldConfig: {
+      defaults: {
+        unit: unit,
+        custom: {
+          fillOpacity: 10,
+          showPoints: 'never',
+          lineWidth: 1,
+        },
+      },
+      overrides: [],
+    },
+    options: {
+      legend: { displayMode: 'list', placement: 'bottom' },
+      tooltip: { mode: 'multi', sort: 'desc' },
+    },
+    targets: withRefIds(targets),
+  },
+
+  stat(title, targets, gridPos, unit='short', thresholds=null):: {
+    type: 'stat',
+    title: title,
+    datasource: datasource,
+    gridPos: gridPos,
+    fieldConfig: {
+      defaults: {
+        unit: unit,
+        [if thresholds != null then 'thresholds']: thresholds,
+      },
+      overrides: [],
+    },
+    options: {
+      colorMode: 'value',
+      graphMode: 'none',
+      reduceOptions: { calcs: ['lastNotNull'] },
+    },
+    targets: withRefIds(targets),
+  },
+}


### PR DESCRIPTION
## Problem

The controller exposes metrics (#344) and the default cloudflared image reports per hostname traffic (#347), but there is no ready to use way to visualize them.

## Solution

Add two Grafana dashboards written in jsonnet, with compiled JSON files committed for direct import.

## Major Changes

- Grafana dashboards (`mixin/`)
  - `controller.json`: sync freshness, managed exposures, Cloudflare API errors, DNS record operations, reconcile rate and duration, workqueue depth
  - `cloudflared.json`: per hostname request rate, status codes, latency percentiles, origin latency breakdown, proxy errors, traffic volume
  - jsonnet sources under `mixin/dashboards/` with a small helper library, compiled output committed under `mixin/dist/`
- Build
  - New `make dashboards` target recompiles the JSON from jsonnet sources
- Documentation
  - Monitoring guide now covers importing the dashboards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only additions (dashboard JSON, jsonnet, docs, Makefile target) with no runtime or controller behavior changes.
> 
> **Overview**
> Adds **ready-to-import Grafana dashboards** for controller and per-hostname cloudflared traffic, plus jsonnet sources and a `make dashboards` build step.
> 
> The new `mixin/` tree includes jsonnet dashboards (`controller.jsonnet`, `cloudflared.jsonnet`) built with a small `grafana.libsonnet` helper, with compiled JSON committed under `mixin/dist/` for direct Grafana import. The **controller** dashboard covers sync age, managed exposures, Cloudflare API and DNS activity, reconcile metrics, workqueue depth, and Kubernetes client traffic. The **cloudflared** dashboard filters by hostname for request/error rates, latency, origin timing, proxy errors, volume, and tunnel-wide concurrency/TCP sessions.
> 
> The monitoring guide and `mixin/README.md` document import steps and note that panels need Prometheus scraping of both metrics endpoints (and per-host metrics from the default patched cloudflared image).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b5c80be509131a3d92fa93f6e7c77cb83ff625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->