### PR TITLE
feat: add Prometheus alert rules for sync health and per-hostname errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,10 @@ e2e: e2e-image
 setup-envtest:
 	bash ./hack/install-setup-envtest.sh
 
-# Compile the Grafana dashboards from jsonnet sources into plain JSON
-# files under mixin/dist. Requires the jsonnet binary.
+# Compile the Grafana dashboards and Prometheus alert rules from jsonnet
+# sources into plain files under mixin/dist. Requires the jsonnet binary.
 .PHONY: dashboards
 dashboards:
 	jsonnet mixin/dashboards/controller.jsonnet > mixin/dist/controller.json
 	jsonnet mixin/dashboards/cloudflared.jsonnet > mixin/dist/cloudflared.json
+	jsonnet -S mixin/alerts/alerts.jsonnet > mixin/dist/alerts.yaml

--- a/docs/src/content/docs/how-to/monitoring.md
+++ b/docs/src/content/docs/how-to/monitoring.md
@@ -94,6 +94,12 @@ The repository ships two ready to import Grafana dashboards in the
 
 Import each file in Grafana with `Dashboards -> New -> Import` and select your Prometheus data source. Both metrics endpoints described above must be scraped for the panels to show data.
 
+## Load the Prometheus alert rules
+
+The same directory ships `alerts.yaml` with alert rules for stale syncs, Cloudflare API errors, high 5xx rates per hostname, and unreachable origin services.
+
+Add the file to the `rule_files` section of your Prometheus configuration, or wrap its `groups` list in a `PrometheusRule` object when using the Prometheus Operator. See the [mixin README](https://github.com/STRRL/cloudflare-tunnel-ingress-controller/tree/master/mixin) for the full alert list.
+
 ## Add cloudflared health probes
 
 The chart copies `cloudflared.probes.liveness`, `readiness`, and `startup` into the managed connector container as Kubernetes probe objects.

--- a/mixin/README.md
+++ b/mixin/README.md
@@ -1,7 +1,7 @@
-# Grafana Dashboards
+# Grafana Dashboards and Alert Rules
 
-Grafana dashboards for the controller and its managed cloudflared connectors,
-written in jsonnet.
+Grafana dashboards and Prometheus alert rules for the controller and its
+managed cloudflared connectors, written in jsonnet.
 
 ## Ready to import JSON
 
@@ -21,6 +21,20 @@ The per hostname panels need the patched cloudflared image
 (`ghcr.io/strrl/cloudflared`), which is the chart default. See the
 [monitoring guide](https://tunnel.strrl.dev/how-to/monitoring/) for how to
 scrape both metrics endpoints.
+
+## Alert rules
+
+`dist/alerts.yaml` contains Prometheus alert rules:
+
+- `CloudflareTunnelSyncStale`: the controller stopped syncing to Cloudflare.
+- `CloudflareTunnelSyncMissing`: the sync metric is gone, controller down or
+  not scraped.
+- `CloudflareTunnelAPIErrors`: Cloudflare API calls keep failing.
+- `CloudflareTunnelHigh5xxRate`: an exposed hostname returns too many 5xx.
+- `CloudflareTunnelProxyErrors`: cloudflared cannot reach an origin service.
+
+Load the file with Prometheus `rule_files`, or wrap the `groups` list in a
+`PrometheusRule` object when using the Prometheus Operator.
 
 ## Rebuild from source
 

--- a/mixin/alerts/alerts.jsonnet
+++ b/mixin/alerts/alerts.jsonnet
@@ -1,0 +1,73 @@
+// Prometheus alert rules for the controller and the managed cloudflared
+// connectors. Compile with `jsonnet -S` to get plain YAML that can be
+// loaded by Prometheus or pasted into a PrometheusRule object.
+local rules = {
+  groups: [
+    {
+      name: 'cloudflare-tunnel-ingress-controller',
+      rules: [
+        {
+          alert: 'CloudflareTunnelSyncStale',
+          expr: 'time() - max(cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds) > 300',
+          'for': '5m',
+          labels: { severity: 'critical' },
+          annotations: {
+            summary: 'Controller has not synced to Cloudflare recently',
+            description: 'The last successful sync to Cloudflare is older than 5 minutes. Ingress changes are not reaching the tunnel. Check the controller logs and the Cloudflare API token.',
+          },
+        },
+        {
+          alert: 'CloudflareTunnelSyncMissing',
+          expr: 'absent(cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds)',
+          'for': '10m',
+          labels: { severity: 'critical' },
+          annotations: {
+            summary: 'Controller sync metric is missing',
+            description: 'The sync timestamp metric is absent. The controller is down or Prometheus is not scraping it.',
+          },
+        },
+        {
+          alert: 'CloudflareTunnelAPIErrors',
+          expr: 'sum(increase(cloudflare_tunnel_ingress_controller_cloudflare_api_errors_total[15m])) > 0',
+          'for': '15m',
+          labels: { severity: 'warning' },
+          annotations: {
+            summary: 'Cloudflare API calls are failing',
+            description: 'The controller keeps hitting Cloudflare API errors. Check the controller logs for the failing operation.',
+          },
+        },
+      ],
+    },
+    {
+      name: 'cloudflare-tunnel-cloudflared',
+      rules: [
+        {
+          alert: 'CloudflareTunnelHigh5xxRate',
+          expr: |||
+            sum by (host) (rate(cloudflared_tunnel_host_requests_total{status=~"5.."}[5m]))
+              / sum by (host) (rate(cloudflared_tunnel_host_requests_total[5m]))
+              > 0.05
+          |||,
+          'for': '10m',
+          labels: { severity: 'warning' },
+          annotations: {
+            summary: 'High 5xx rate for {{ $labels.host }}',
+            description: 'More than 5% of requests to {{ $labels.host }} return a 5xx status. Check the origin service behind this hostname.',
+          },
+        },
+        {
+          alert: 'CloudflareTunnelProxyErrors',
+          expr: 'sum by (host) (rate(cloudflared_tunnel_host_request_errors_total[5m])) > 0.1',
+          'for': '10m',
+          labels: { severity: 'warning' },
+          annotations: {
+            summary: 'cloudflared cannot reach the origin for {{ $labels.host }}',
+            description: 'cloudflared keeps failing to proxy requests for {{ $labels.host }}. The origin service is likely unreachable from the connector pod.',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+std.manifestYamlDoc(rules, quote_keys=false)

--- a/mixin/dist/alerts.yaml
+++ b/mixin/dist/alerts.yaml
@@ -1,0 +1,48 @@
+groups:
+- name: "cloudflare-tunnel-ingress-controller"
+  rules:
+  - alert: "CloudflareTunnelSyncStale"
+    annotations:
+      description: "The last successful sync to Cloudflare is older than 5 minutes. Ingress changes are not reaching the tunnel. Check the controller logs and the Cloudflare API token."
+      summary: "Controller has not synced to Cloudflare recently"
+    expr: "time() - max(cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds) > 300"
+    for: "5m"
+    labels:
+      severity: "critical"
+  - alert: "CloudflareTunnelSyncMissing"
+    annotations:
+      description: "The sync timestamp metric is absent. The controller is down or Prometheus is not scraping it."
+      summary: "Controller sync metric is missing"
+    expr: "absent(cloudflare_tunnel_ingress_controller_last_successful_sync_timestamp_seconds)"
+    for: "10m"
+    labels:
+      severity: "critical"
+  - alert: "CloudflareTunnelAPIErrors"
+    annotations:
+      description: "The controller keeps hitting Cloudflare API errors. Check the controller logs for the failing operation."
+      summary: "Cloudflare API calls are failing"
+    expr: "sum(increase(cloudflare_tunnel_ingress_controller_cloudflare_api_errors_total[15m])) > 0"
+    for: "15m"
+    labels:
+      severity: "warning"
+- name: "cloudflare-tunnel-cloudflared"
+  rules:
+  - alert: "CloudflareTunnelHigh5xxRate"
+    annotations:
+      description: "More than 5% of requests to {{ $labels.host }} return a 5xx status. Check the origin service behind this hostname."
+      summary: "High 5xx rate for {{ $labels.host }}"
+    expr: |
+      sum by (host) (rate(cloudflared_tunnel_host_requests_total{status=~"5.."}[5m]))
+        / sum by (host) (rate(cloudflared_tunnel_host_requests_total[5m]))
+        > 0.05
+    for: "10m"
+    labels:
+      severity: "warning"
+  - alert: "CloudflareTunnelProxyErrors"
+    annotations:
+      description: "cloudflared keeps failing to proxy requests for {{ $labels.host }}. The origin service is likely unreachable from the connector pod."
+      summary: "cloudflared cannot reach the origin for {{ $labels.host }}"
+    expr: "sum by (host) (rate(cloudflared_tunnel_host_request_errors_total[5m])) > 0.1"
+    for: "10m"
+    labels:
+      severity: "warning"


### PR DESCRIPTION
## Problem

The dashboards (#348) let you look at metrics, but nothing tells you when the controller stops syncing or an exposed hostname starts failing.

## Solution

Add Prometheus alert rules in jsonnet next to the dashboards, with compiled YAML committed for direct use.

## Major Changes

- Alert rules (`mixin/alerts/`, compiled to `mixin/dist/alerts.yaml`)
  - Controller: sync stale for 5 minutes, sync metric absent, repeated Cloudflare API errors
  - cloudflared: 5xx ratio above 5% per hostname, repeated proxy errors to an origin
  - Validated with promtool
- Build
  - `make dashboards` also compiles the alert rules
- Documentation
  - Monitoring guide and mixin README cover loading the rules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are jsonnet/YAML alert definitions and docs only; no controller or chart runtime behavior is modified.
> 
> **Overview**
> Adds **Prometheus alert rules** alongside the existing Grafana dashboards so operators get notified when sync or traffic health degrades, not only when they open Grafana.
> 
> New jsonnet in `mixin/alerts/alerts.jsonnet` compiles to **`mixin/dist/alerts.yaml`**. Controller rules cover **stale sync** (last successful sync older than 5 minutes), **missing sync metric**, and **sustained Cloudflare API errors**. cloudflared rules cover **>5% 5xx rate per hostname** and **elevated proxy errors** to origins.
> 
> **`make dashboards`** now also builds `alerts.yaml` via `jsonnet -S`. The monitoring guide and mixin README describe loading the file via Prometheus `rule_files` or a `PrometheusRule` for the Operator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b260e9272c72c5c55fa4ceb9ac05c7b4149c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->