### PR TITLE
fix(dns): quote ownership TXT records and avoid * in wildcard TXT names

### DIFF
--- a/docs/src/content/docs/explanation/architecture.md
+++ b/docs/src/content/docs/explanation/architecture.md
@@ -44,7 +44,11 @@ flowchart TB
     Disabled --> Relinquish["Controller removes its ownership TXT<br/>and removes the CNAME only if it still points to this tunnel"]
 ```
 
-The CNAME sends public traffic toward `<tunnel-id>.cfargotunnel.com`. The TXT record gives cleanup a safe ownership boundary, so a matching ownership record is required before normal reconciliation deletes a CNAME.
+The CNAME sends public traffic toward `<tunnel-id>.cfargotunnel.com`. The TXT record gives cleanup a safe ownership boundary, so a matching ownership record is required before normal reconciliation deletes a CNAME. TXT values are RFC 1035-quoted JSON. For a wildcard hostname such as `*.example.com`, the ownership record is `_ctic_managed._wildcard.example.com` so Cloudflare does not warn about a non-prefix asterisk, and so the name cannot collide with a literal `wildcard.example.com` host.
+
+After upgrade, the next reconciliation rewrites existing ownership TXT records automatically: wildcard names move from `_ctic_managed.*.example.com` to `_ctic_managed._wildcard.example.com`, and unquoted JSON is stored as RFC 1035-quoted character-strings. No manual DNS edits are required. The CNAME is unchanged, so traffic is unaffected.
+
+Ownership recognition is not backwards compatible. A release from before the rewrite compares TXT content literally, so it does not recognise the quoted values: it logs its own hostnames as unmanaged and stops deleting their CNAMEs when the Ingress goes away. If you roll back, delete the `_ctic_managed.` TXT records for the affected hostnames so the older release recreates them in the format it understands.
 
 With `disable-dns-management: "true"`, only DNS responsibility changes. The Exposure still becomes a tunnel rule, but the controller stops creating or updating DNS records and permits hostnames outside its visible Cloudflare zones. When relinquishing records it previously managed, it preserves any CNAME another system has already repointed.
 

--- a/docs/src/content/docs/reference/ingress.md
+++ b/docs/src/content/docs/reference/ingress.md
@@ -25,7 +25,11 @@ Consult the [ingress annotations reference](/reference/ingress-annotations/) for
 
 ## Wildcard hostnames
 
-Hosts may use a leading wildcard label such as `*.example.com`. The controller creates the matching wildcard DNS record and orders the tunnel rules so that routing behaves as you would expect:
+Hosts may use a leading wildcard label such as `*.example.com`. The controller creates the matching wildcard CNAME and an ownership TXT record at `_ctic_managed._wildcard.example.com`.
+
+The `_wildcard` label stands in for `*` for two reasons: Cloudflare warns about an asterisk that is not the leftmost `*.` prefix, and the leading underscore keeps the name distinct from a host that is literally `wildcard.example.com`.
+
+Tunnel rules are ordered so that routing behaves as you would expect:
 
 - An exact hostname always wins over a wildcard. With rules for `app.example.com` and `*.example.com`, requests to `app.example.com` reach the exact rule and any other subdomain falls back to the wildcard.
 - A more specific wildcard wins over a broader one. `*.internal.example.com` is matched before `*.example.com`.

--- a/pkg/cloudflare-controller/dns.go
+++ b/pkg/cloudflare-controller/dns.go
@@ -13,6 +13,15 @@ import (
 
 const ManagedRecordTXTPrefix = "_ctic_managed"
 
+// wildcardTXTLabel replaces "*" in ownership TXT names to suppress Cloudflare's
+// warning that a star is only a wildcard as the leftmost "*." prefix.
+//
+// The leading underscore keeps this distinct from a literal Ingress host:
+// Kubernetes hostnames are DNS-1123 (letters, digits, hyphen), so
+// "*.example.com" maps to _ctic_managed._wildcard.example.com while
+// "wildcard.example.com" maps to _ctic_managed.wildcard.example.com.
+const wildcardTXTLabel = "_wildcard"
+
 type ManagedRecordTXTContent struct {
 	Controller string `json:"controller"`
 	Tunnel     string `json:"tunnel"`
@@ -45,10 +54,13 @@ type DNSOperationDelete struct {
 //
 // For each exposure hostname (e.g., 'dash.strrl.cloud'), it manages two records:
 // - CNAME: dash.strrl.cloud -> <tunnel-id>.cfargotunnel.com (proxied)
-// - TXT: _ctic_managed.dash.strrl.cloud -> JSON content identifying the controller and tunnel
+// - TXT: _ctic_managed.dash.strrl.cloud -> RFC 1035-quoted JSON identifying the controller and tunnel
 //
-// The TXT record is used to identify records managed by this controller.
-// Deletion only occurs when a matching TXT record exists for the current tunnel.
+// Wildcard hostnames replace "*" with "_wildcard" in the TXT name, e.g.
+// *.example.com -> _ctic_managed._wildcard.example.com, so Cloudflare does
+// not warn about a non-prefix asterisk. That label also cannot collide with
+// a literal wildcard.example.com host. The TXT record proves ownership;
+// deletion only occurs when a matching TXT record exists for the current tunnel.
 func syncDNSRecord(
 	logger logr.Logger,
 	exposures []exposure.Exposure,
@@ -68,8 +80,21 @@ func syncDNSRecord(
 		return nil, nil, nil, errors.Wrap(err, "render managed record TXT content")
 	}
 
+	// Every path of an Ingress becomes its own Exposure, so a hostname is
+	// usually visited several times while it resolves to the same pair of DNS
+	// records. Handling it once keeps the operation list and the migration logs
+	// free of repetition. DisableDNSManagement belongs in the key because it
+	// selects which branch below runs.
+	handledHostnames := map[string]struct{}{}
+
 	// Create or update CNAME/TXT records for active exposures
 	for _, item := range effectiveExposures {
+		hostnameKey := fmt.Sprintf("%t/%s", item.DisableDNSManagement, item.Hostname)
+		if _, handled := handledHostnames[hostnameKey]; handled {
+			continue
+		}
+		handledHostnames[hostnameKey] = struct{}{}
+
 		txtRecordName := managedTXTRecordName(item.Hostname)
 
 		// DNS management is delegated externally for this exposure: relinquish
@@ -79,8 +104,8 @@ func syncDNSRecord(
 		// external system already repointed it the record must survive and only
 		// the ownership TXT is dropped.
 		if item.DisableDNSManagement {
-			containsTXT, oldTXT := dnsRecordsContainsHostname(existedTXTRecords, txtRecordName)
-			if containsTXT && oldTXT.Content == expectedTXTContent {
+			ownedTXTs := ownedTXTRecords(existedTXTRecords, item.Hostname, expectedTXTContent)
+			if len(ownedTXTs) > 0 {
 				containsCNAME, oldCNAME := dnsRecordsContainsHostname(existedCNAMERecords, item.Hostname)
 				if containsCNAME && oldCNAME.Content == tunnelDomain(tunnelId) {
 					toDelete = append(toDelete, DNSOperationDelete{
@@ -90,9 +115,11 @@ func syncDNSRecord(
 						"hostname", item.Hostname,
 					)
 				}
-				toDelete = append(toDelete, DNSOperationDelete{
-					OldRecord: oldTXT,
-				})
+				for _, oldTXT := range ownedTXTs {
+					toDelete = append(toDelete, DNSOperationDelete{
+						OldRecord: oldTXT,
+					})
+				}
 				logger.Info("DNS management disabled, relinquishing ownership TXT record",
 					"hostname", item.Hostname,
 				)
@@ -104,8 +131,7 @@ func syncDNSRecord(
 		containsCNAME, oldCNAME := dnsRecordsContainsHostname(existedCNAMERecords, item.Hostname)
 		if containsCNAME {
 			// Check if this record is managed by this controller
-			hasTXTRecord, _ := dnsRecordsContainsHostname(existedTXTRecords, txtRecordName)
-			if !hasTXTRecord {
+			if !hasOwnershipTXTName(existedTXTRecords, item.Hostname) {
 				logger.Info("WARNING: overriding DNS record not managed by this controller",
 					"hostname", item.Hostname,
 					"existing-content", oldCNAME.Content,
@@ -124,9 +150,14 @@ func syncDNSRecord(
 			})
 		}
 
-		// Handle TXT record
+		// Handle TXT record at the current name (* replaced with _wildcard).
 		containsTXT, oldTXT := dnsRecordsContainsHostname(existedTXTRecords, txtRecordName)
 		if containsTXT {
+			if oldTXT.Content != expectedTXTContent && txtContentEqual(oldTXT.Content, expectedTXTContent) {
+				logger.Info("migrating ownership TXT record to RFC 1035 quoted form",
+					"hostname", txtRecordName,
+				)
+			}
 			toUpdate = append(toUpdate, DNSOperationUpdate{
 				OldRecord: oldTXT,
 				Type:      "TXT",
@@ -139,6 +170,18 @@ func syncDNSRecord(
 				Content:  expectedTXTContent,
 			})
 		}
+
+		// Drop leftover TXT names that still embed "*" and trigger Cloudflare's warning.
+		for _, leftover := range leftoverLegacyWildcardTXTRecords(existedTXTRecords, item.Hostname, expectedTXTContent) {
+			logger.Info("migrating wildcard ownership TXT record",
+				"hostname", item.Hostname,
+				"from", leftover.Name,
+				"to", txtRecordName,
+			)
+			toDelete = append(toDelete, DNSOperationDelete{
+				OldRecord: leftover,
+			})
+		}
 	}
 
 	// Delete CNAME/TXT records for removed exposures (only if managed by this tunnel)
@@ -148,22 +191,70 @@ func syncDNSRecord(
 			continue
 		}
 
-		// Check if there's a corresponding TXT record managed by this tunnel
-		txtRecordName := managedTXTRecordName(cnameRecord.Name)
-		hasMatchingTXT, matchingTXTRecord := findMatchingTXTRecord(existedTXTRecords, txtRecordName, expectedTXTContent)
-
-		// Only delete if we have a matching TXT record (proves ownership)
-		if hasMatchingTXT {
-			toDelete = append(toDelete, DNSOperationDelete{
-				OldRecord: cnameRecord,
-			})
+		ownedTXTs := ownedTXTRecords(existedTXTRecords, cnameRecord.Name, expectedTXTContent)
+		if len(ownedTXTs) == 0 {
+			continue
+		}
+		toDelete = append(toDelete, DNSOperationDelete{
+			OldRecord: cnameRecord,
+		})
+		for _, matchingTXTRecord := range ownedTXTs {
 			toDelete = append(toDelete, DNSOperationDelete{
 				OldRecord: matchingTXTRecord,
 			})
 		}
 	}
 
-	return toCreate, toUpdate, toDelete, nil
+	return deduplicateDNSCreates(toCreate), deduplicateDNSUpdates(toUpdate), deduplicateDNSDeletes(toDelete), nil
+}
+
+func deduplicateDNSCreates(operations []DNSOperationCreate) []DNSOperationCreate {
+	var result []DNSOperationCreate
+	seen := map[string]struct{}{}
+	for _, operation := range operations {
+		key := operation.Type + "\x00" + operation.Hostname
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, operation)
+	}
+	return result
+}
+
+func deduplicateDNSUpdates(operations []DNSOperationUpdate) []DNSOperationUpdate {
+	var result []DNSOperationUpdate
+	seen := map[string]struct{}{}
+	for _, operation := range operations {
+		key := dnsRecordKey(operation.OldRecord)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, operation)
+	}
+	return result
+}
+
+func deduplicateDNSDeletes(operations []DNSOperationDelete) []DNSOperationDelete {
+	var result []DNSOperationDelete
+	seen := map[string]struct{}{}
+	for _, operation := range operations {
+		key := dnsRecordKey(operation.OldRecord)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, operation)
+	}
+	return result
+}
+
+func dnsRecordKey(record cloudflare.DNSRecord) string {
+	if record.ID != "" {
+		return record.ID
+	}
+	return record.Type + "\x00" + record.Name + "\x00" + record.Content
 }
 
 // migrateLegacyDNSRecords handles migration from the old comment-based ownership to TXT-based ownership.
@@ -194,9 +285,7 @@ func migrateLegacyDNSRecords(
 		}
 
 		// Skip records already tracked by TXT (handled by syncDNSRecord)
-		txtRecordName := managedTXTRecordName(cnameRecord.Name)
-		hasTXTRecord, _ := findMatchingTXTRecord(existedTXTRecords, txtRecordName, expectedTXTContent)
-		if hasTXTRecord {
+		if len(ownedTXTRecords(existedTXTRecords, cnameRecord.Name, expectedTXTContent)) > 0 {
 			continue
 		}
 
@@ -224,16 +313,83 @@ func dnsRecordsContainsHostname(records []cloudflare.DNSRecord, hostname string)
 }
 
 // managedTXTRecordName returns the name of the ownership TXT record that tracks
-// the given hostname, e.g. "_ctic_managed.dash.strrl.cloud".
+// the given hostname. For example:
+//
+//	dash.strrl.cloud     -> _ctic_managed.dash.strrl.cloud
+//	wildcard.example.com -> _ctic_managed.wildcard.example.com
+//	*.example.com        -> _ctic_managed._wildcard.example.com
+//
+// The "*" label is replaced with "_wildcard" to suppress Cloudflare's warning
+// that a star is only a wildcard as the leftmost "*." prefix. The underscore
+// keeps this distinct from a literal "wildcard." hostname: Ingress hosts are
+// DNS-1123 and cannot contain underscores.
 func managedTXTRecordName(hostname string) string {
-	return fmt.Sprintf("%s.%s", ManagedRecordTXTPrefix, hostname)
+	return fmt.Sprintf("%s.%s", ManagedRecordTXTPrefix, dnsNameForTXT(hostname))
+}
+
+func dnsNameForTXT(hostname string) string {
+	if strings.HasPrefix(hostname, "*.") {
+		return wildcardTXTLabel + "." + hostname[2:]
+	}
+	return hostname
+}
+
+// ownershipTXTNames returns the current TXT name and, for wildcards, the
+// historical name that embedded a literal "*" in the record.
+func ownershipTXTNames(hostname string) []string {
+	current := managedTXTRecordName(hostname)
+	legacy := fmt.Sprintf("%s.%s", ManagedRecordTXTPrefix, hostname)
+	if current == legacy {
+		return []string{current}
+	}
+	return []string{current, legacy}
+}
+
+func hasOwnershipTXTName(records []cloudflare.DNSRecord, hostname string) bool {
+	for _, name := range ownershipTXTNames(hostname) {
+		if contains, _ := dnsRecordsContainsHostname(records, name); contains {
+			return true
+		}
+	}
+	return false
+}
+
+func ownedTXTRecords(records []cloudflare.DNSRecord, hostname string, expectedContent string) []cloudflare.DNSRecord {
+	var owned []cloudflare.DNSRecord
+	for _, name := range ownershipTXTNames(hostname) {
+		if has, rec := findMatchingTXTRecord(records, name, expectedContent); has {
+			owned = append(owned, rec)
+		}
+	}
+	return owned
+}
+
+// leftoverLegacyWildcardTXTRecords returns owned TXT records that still use the
+// historical "*" name, so that wildcard ownership migrates automatically. They
+// are reported as deletions, and updateDNSCNAMERecordForZone applies creations
+// before deletions, so the current `_wildcard` record is always in place before
+// the old one goes away.
+func leftoverLegacyWildcardTXTRecords(records []cloudflare.DNSRecord, hostname string, expectedContent string) []cloudflare.DNSRecord {
+	current := managedTXTRecordName(hostname)
+	var leftovers []cloudflare.DNSRecord
+	for _, name := range ownershipTXTNames(hostname) {
+		if name == current {
+			continue
+		}
+		if has, rec := findMatchingTXTRecord(records, name, expectedContent); has {
+			leftovers = append(leftovers, rec)
+		}
+	}
+	return leftovers
 }
 
 // findMatchingTXTRecord returns the TXT record matching both name and content,
 // used to prove this controller/tunnel owns the corresponding CNAME record.
+// Quoted and unquoted payloads are treated as equal so records created before
+// RFC 1035 quoting was added still prove ownership.
 func findMatchingTXTRecord(records []cloudflare.DNSRecord, name string, content string) (bool, cloudflare.DNSRecord) {
 	for _, record := range records {
-		if record.Name == name && record.Content == content {
+		if record.Name == name && txtContentEqual(record.Content, content) {
 			return true, record
 		}
 	}
@@ -268,13 +424,96 @@ func renderTXTContent(tunnelName string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "marshal managed record TXT content")
 	}
-	return string(jsonBytes), nil
+	return quoteTXTContent(string(jsonBytes)), nil
 }
 
 func parseTXTContent(content string) (*ManagedRecordTXTContent, error) {
 	var result ManagedRecordTXTContent
-	if err := json.Unmarshal([]byte(content), &result); err != nil {
+	if err := json.Unmarshal([]byte(unquoteTXTContent(content)), &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
+}
+
+func txtContentEqual(a, b string) bool {
+	return unquoteTXTContent(a) == unquoteTXTContent(b)
+}
+
+// txtCharacterStringLimit is the maximum length of one RFC 1035 character-string.
+// Cloudflare splits longer payloads on its own, so splitting them here keeps the
+// stored content identical to what was sent and avoids a permanent mismatch
+// between the expected and the observed record.
+const txtCharacterStringLimit = 255
+
+// quoteTXTContent renders s as RFC 1035 character-strings, escaping inner quotes
+// and backslashes so the TXT RDATA is unambiguous. Payloads that exceed a single
+// character-string are split into space separated chunks, which receivers
+// concatenate back into the original value.
+func quoteTXTContent(s string) string {
+	if s == "" {
+		return `""`
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	for start := 0; start < len(s); start += txtCharacterStringLimit {
+		if start > 0 {
+			b.WriteByte(' ')
+		}
+		writeTXTCharacterString(&b, s[start:min(start+txtCharacterStringLimit, len(s))])
+	}
+	return b.String()
+}
+
+func writeTXTCharacterString(b *strings.Builder, s string) {
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\', '"':
+			b.WriteByte('\\')
+		}
+		b.WriteByte(s[i])
+	}
+	b.WriteByte('"')
+}
+
+// unquoteTXTContent returns the logical TXT payload, accepting both the
+// historical unquoted JSON and the RFC 1035 quoted form, including the multiple
+// character-strings Cloudflare produces for long values. Input that is not
+// well-formed quoting is returned as-is rather than half decoded.
+func unquoteTXTContent(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || s[0] != '"' {
+		return s
+	}
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == ' ' {
+			i++
+			continue
+		}
+		if s[i] != '"' {
+			return s
+		}
+		i++
+		closed := false
+		for i < len(s) {
+			if s[i] == '\\' && i+1 < len(s) {
+				b.WriteByte(s[i+1])
+				i += 2
+				continue
+			}
+			if s[i] == '"' {
+				i++
+				closed = true
+				break
+			}
+			b.WriteByte(s[i])
+			i++
+		}
+		if !closed {
+			return s
+		}
+	}
+	return b.String()
 }

--- a/pkg/cloudflare-controller/dns_test.go
+++ b/pkg/cloudflare-controller/dns_test.go
@@ -2,6 +2,7 @@ package cloudflarecontroller
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/STRRL/cloudflare-tunnel-ingress-controller/pkg/exposure"
@@ -11,6 +12,14 @@ import (
 
 const WhateverTunnelId = "whatever"
 const WhateverTunnelDomain = "whatever.cfargotunnel.com"
+
+func mustRenderTXTContent(tunnelName string) string {
+	content, err := renderTXTContent(tunnelName)
+	if err != nil {
+		panic(err)
+	}
+	return content
+}
 
 func Test_syncDNSRecord(t *testing.T) {
 	type args struct {
@@ -69,7 +78,7 @@ func Test_syncDNSRecord(t *testing.T) {
 				{
 					Hostname: "_ctic_managed.test.example.com",
 					Type:     "TXT",
-					Content:  `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					Content:  mustRenderTXTContent("tunnel-in-test"),
 				},
 			},
 			wantUpdate: nil,
@@ -108,7 +117,7 @@ func Test_syncDNSRecord(t *testing.T) {
 				{
 					Hostname: "_ctic_managed.test2.example.com",
 					Type:     "TXT",
-					Content:  `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					Content:  mustRenderTXTContent("tunnel-in-test"),
 				},
 			},
 			wantUpdate: nil,
@@ -136,7 +145,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 				tunnelId:   WhateverTunnelId,
@@ -156,7 +165,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					OldRecord: cloudflare.DNSRecord{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 			},
@@ -189,7 +198,7 @@ func Test_syncDNSRecord(t *testing.T) {
 				{
 					Hostname: "_ctic_managed.test.example.com",
 					Type:     "TXT",
-					Content:  `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					Content:  mustRenderTXTContent("tunnel-in-test"),
 				},
 			},
 			wantUpdate: []DNSOperationUpdate{
@@ -229,7 +238,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 				tunnelId:   WhateverTunnelId,
@@ -249,7 +258,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					OldRecord: cloudflare.DNSRecord{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 			},
@@ -257,6 +266,59 @@ func Test_syncDNSRecord(t *testing.T) {
 		},
 		{
 			name: "always update existing record with TXT",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "test.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("tunnel-in-test"),
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: []DNSOperationUpdate{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+					Type:    "CNAME",
+					Content: WhateverTunnelDomain,
+				},
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("tunnel-in-test"),
+					},
+					Type:    "TXT",
+					Content: mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
+			wantDelete: nil,
+			wantErr:    false,
+		},
+		{
+			name: "rewrites unquoted ownership TXT to RFC 1035 quoted form",
 			args: args{
 				logger: logr.Discard(),
 				exposures: []exposure.Exposure{
@@ -302,7 +364,7 @@ func Test_syncDNSRecord(t *testing.T) {
 						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
 					},
 					Type:    "TXT",
-					Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					Content: mustRenderTXTContent("tunnel-in-test"),
 				},
 			},
 			wantDelete: nil,
@@ -324,7 +386,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"different-tunnel"}`,
+						Content: mustRenderTXTContent("different-tunnel"),
 					},
 				},
 				tunnelId:   "current-tunnel-id",
@@ -382,7 +444,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 				tunnelId:   WhateverTunnelId,
@@ -402,7 +464,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					OldRecord: cloudflare.DNSRecord{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 			},
@@ -432,7 +494,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 				tunnelId:   WhateverTunnelId,
@@ -445,7 +507,7 @@ func Test_syncDNSRecord(t *testing.T) {
 					OldRecord: cloudflare.DNSRecord{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 			},
@@ -475,13 +537,433 @@ func Test_syncDNSRecord(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"another-tunnel"}`,
+						Content: mustRenderTXTContent("another-tunnel"),
 					},
 				},
 				tunnelId:   WhateverTunnelId,
 				tunnelName: "tunnel-in-test",
 			},
 			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: nil,
+			wantErr:    false,
+		},
+		{
+			name: "wildcard hostname uses wildcard-safe TXT name",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "*.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: nil,
+				existedTXTRecords:   nil,
+				tunnelId:            WhateverTunnelId,
+				tunnelName:          "tunnel-in-test",
+			},
+			wantCreate: []DNSOperationCreate{
+				{
+					Hostname: "*.example.com",
+					Type:     "CNAME",
+					Content:  WhateverTunnelDomain,
+				},
+				{
+					Hostname: "_ctic_managed._wildcard.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
+			wantUpdate: nil,
+			wantDelete: nil,
+			wantErr:    false,
+		},
+		{
+			name: "migrates unquoted asterisk TXT name to quoted _wildcard name",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "*.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: []DNSOperationCreate{
+				{
+					Hostname: "_ctic_managed._wildcard.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
+			wantUpdate: []DNSOperationUpdate{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+					Type:    "CNAME",
+					Content: WhateverTunnelDomain,
+				},
+			},
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "deduplicates wildcard migration operations for multiple paths",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "*.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/api",
+						IsDeleted:     false,
+					},
+					{
+						Hostname:      "*.example.com",
+						ServiceTarget: "http://10.0.0.2:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						ID:      "wildcard-cname",
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						ID:      "legacy-wildcard-txt",
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: []DNSOperationCreate{
+				{
+					Hostname: "_ctic_managed._wildcard.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
+			wantUpdate: []DNSOperationUpdate{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						ID:      "wildcard-cname",
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+					Type:    "CNAME",
+					Content: WhateverTunnelDomain,
+				},
+			},
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						ID:      "legacy-wildcard-txt",
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unquoted legacy TXT content still proves ownership",
+			args: args{
+				logger:    logr.Discard(),
+				exposures: nil,
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "test.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed.test.example.com",
+						Type:    "TXT",
+						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "deletes wildcard CNAME using wildcard-safe TXT name",
+			args: args{
+				logger:    logr.Discard(),
+				exposures: nil,
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed._wildcard.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("tunnel-in-test"),
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed._wildcard.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("tunnel-in-test"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "wildcard and literal wildcard hostname get distinct TXT names",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "*.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+					{
+						Hostname:      "wildcard.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: nil,
+				existedTXTRecords:   nil,
+				tunnelId:            WhateverTunnelId,
+				tunnelName:          "tunnel-in-test",
+			},
+			wantCreate: []DNSOperationCreate{
+				{
+					Hostname: "*.example.com",
+					Type:     "CNAME",
+					Content:  WhateverTunnelDomain,
+				},
+				{
+					Hostname: "_ctic_managed._wildcard.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+				{
+					Hostname: "wildcard.example.com",
+					Type:     "CNAME",
+					Content:  WhateverTunnelDomain,
+				},
+				{
+					Hostname: "_ctic_managed.wildcard.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
+			wantUpdate: nil,
+			wantDelete: nil,
+			wantErr:    false,
+		},
+		{
+			name: "wildcard exposure with DNS management disabled relinquishes the legacy asterisk TXT",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:             "*.example.com",
+						ServiceTarget:        "http://10.0.0.1:233",
+						PathPrefix:           "/",
+						IsDeleted:            false,
+						DisableDNSManagement: true,
+					},
+				},
+				existedCNAMERecords: []cloudflare.DNSRecord{
+					{
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("tunnel-in-test"),
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: []DNSOperationDelete{
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "*.example.com",
+						Type:    "CNAME",
+						Content: WhateverTunnelDomain,
+					},
+				},
+				{
+					OldRecord: cloudflare.DNSRecord{
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("tunnel-in-test"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "legacy asterisk TXT owned by another tunnel is left untouched",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "*.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: nil,
+				existedTXTRecords: []cloudflare.DNSRecord{
+					{
+						Name:    "_ctic_managed.*.example.com",
+						Type:    "TXT",
+						Content: mustRenderTXTContent("another-tunnel"),
+					},
+				},
+				tunnelId:   WhateverTunnelId,
+				tunnelName: "tunnel-in-test",
+			},
+			wantCreate: []DNSOperationCreate{
+				{
+					Hostname: "*.example.com",
+					Type:     "CNAME",
+					Content:  WhateverTunnelDomain,
+				},
+				{
+					Hostname: "_ctic_managed._wildcard.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
+			wantUpdate: nil,
+			wantDelete: nil,
+			wantErr:    false,
+		},
+		{
+			name: "hostname exposed on several paths yields one operation per record",
+			args: args{
+				logger: logr.Discard(),
+				exposures: []exposure.Exposure{
+					{
+						Hostname:      "test.example.com",
+						ServiceTarget: "http://10.0.0.1:233",
+						PathPrefix:    "/api",
+						IsDeleted:     false,
+					},
+					{
+						Hostname:      "test.example.com",
+						ServiceTarget: "http://10.0.0.2:233",
+						PathPrefix:    "/",
+						IsDeleted:     false,
+					},
+				},
+				existedCNAMERecords: nil,
+				existedTXTRecords:   nil,
+				tunnelId:            WhateverTunnelId,
+				tunnelName:          "tunnel-in-test",
+			},
+			wantCreate: []DNSOperationCreate{
+				{
+					Hostname: "test.example.com",
+					Type:     "CNAME",
+					Content:  WhateverTunnelDomain,
+				},
+				{
+					Hostname: "_ctic_managed.test.example.com",
+					Type:     "TXT",
+					Content:  mustRenderTXTContent("tunnel-in-test"),
+				},
+			},
 			wantUpdate: nil,
 			wantDelete: nil,
 			wantErr:    false,
@@ -614,7 +1096,7 @@ func Test_migrateLegacyDNSRecords(t *testing.T) {
 					{
 						Name:    "_ctic_managed.test.example.com",
 						Type:    "TXT",
-						Content: `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"tunnel-in-test"}`,
+						Content: mustRenderTXTContent("tunnel-in-test"),
 					},
 				},
 				tunnelName: "tunnel-in-test",
@@ -646,23 +1128,102 @@ func Test_renderTXTContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderTXTContent() unexpected error: %v", err)
 	}
-	expected := `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"my-tunnel"}`
+	expected := `"{\"controller\":\"strrl.dev/cloudflare-tunnel-ingress-controller\",\"tunnel\":\"my-tunnel\"}"`
 	if result != expected {
 		t.Errorf("renderTXTContent() = %v, want %v", result, expected)
 	}
 }
 
 func Test_parseTXTContent(t *testing.T) {
-	content := `{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"my-tunnel"}`
-	result, err := parseTXTContent(content)
-	if err != nil {
-		t.Errorf("parseTXTContent() error = %v", err)
-		return
+	payloads := []string{
+		`{"controller":"strrl.dev/cloudflare-tunnel-ingress-controller","tunnel":"my-tunnel"}`,
+		`"{\"controller\":\"strrl.dev/cloudflare-tunnel-ingress-controller\",\"tunnel\":\"my-tunnel\"}"`,
 	}
-	if result.Controller != ControllerIdentifier {
-		t.Errorf("parseTXTContent() Controller = %v, want %v", result.Controller, ControllerIdentifier)
+	for _, content := range payloads {
+		result, err := parseTXTContent(content)
+		if err != nil {
+			t.Errorf("parseTXTContent(%q) error = %v", content, err)
+			continue
+		}
+		if result.Controller != ControllerIdentifier {
+			t.Errorf("parseTXTContent(%q) Controller = %v, want %v", content, result.Controller, ControllerIdentifier)
+		}
+		if result.Tunnel != "my-tunnel" {
+			t.Errorf("parseTXTContent(%q) Tunnel = %v, want %v", content, result.Tunnel, "my-tunnel")
+		}
 	}
-	if result.Tunnel != "my-tunnel" {
-		t.Errorf("parseTXTContent() Tunnel = %v, want %v", result.Tunnel, "my-tunnel")
+}
+
+func Test_managedTXTRecordName(t *testing.T) {
+	tests := []struct {
+		hostname string
+		want     string
+	}{
+		{hostname: "test.example.com", want: "_ctic_managed.test.example.com"},
+		{hostname: "example.com", want: "_ctic_managed.example.com"},
+		{hostname: "wildcard.example.com", want: "_ctic_managed.wildcard.example.com"},
+		{hostname: "*.example.com", want: "_ctic_managed._wildcard.example.com"},
+		{hostname: "*.foo.example.com", want: "_ctic_managed._wildcard.foo.example.com"},
+	}
+	for _, tt := range tests {
+		if got := managedTXTRecordName(tt.hostname); got != tt.want {
+			t.Errorf("managedTXTRecordName(%q) = %q, want %q", tt.hostname, got, tt.want)
+		}
+	}
+}
+
+func Test_quoteTXTContent(t *testing.T) {
+	quoted := quoteTXTContent(`{"controller":"example","tunnel":"t"}`)
+	expected := `"{\"controller\":\"example\",\"tunnel\":\"t\"}"`
+	if quoted != expected {
+		t.Errorf("quoteTXTContent() = %q, want %q", quoted, expected)
+	}
+	if got := unquoteTXTContent(quoted); got != `{"controller":"example","tunnel":"t"}` {
+		t.Errorf("unquoteTXTContent() = %q, want original JSON", got)
+	}
+	if got := unquoteTXTContent(`{"controller":"example","tunnel":"t"}`); got != `{"controller":"example","tunnel":"t"}` {
+		t.Errorf("unquoteTXTContent() unquoted input = %q", got)
+	}
+}
+
+func Test_quoteTXTContentSplitsLongPayload(t *testing.T) {
+	payload := strings.Repeat("a", txtCharacterStringLimit) + strings.Repeat("b", 10)
+	quoted := quoteTXTContent(payload)
+	expected := `"` + strings.Repeat("a", txtCharacterStringLimit) + `" "` + strings.Repeat("b", 10) + `"`
+	if quoted != expected {
+		t.Errorf("quoteTXTContent() = %q, want %q", quoted, expected)
+	}
+	if got := unquoteTXTContent(quoted); got != payload {
+		t.Errorf("unquoteTXTContent() = %q, want the original payload", got)
+	}
+}
+
+// Cloudflare splits stored TXT values into multiple character-strings, so the
+// ownership record must still be recognised after a round trip through the API.
+func Test_txtContentEqualAcrossCloudflareSplitting(t *testing.T) {
+	expected := mustRenderTXTContent(strings.Repeat("long-tunnel-name", 20))
+	payload := unquoteTXTContent(expected)
+	var split strings.Builder
+	for start := 0; start < len(payload); start += 100 {
+		if start > 0 {
+			split.WriteString(" ")
+		}
+		split.WriteString(quoteTXTContent(payload[start:min(start+100, len(payload))]))
+	}
+	if !txtContentEqual(split.String(), expected) {
+		t.Errorf("txtContentEqual() = false for re-split content %q", split.String())
+	}
+}
+
+func Test_unquoteTXTContentMalformedInput(t *testing.T) {
+	tests := []string{
+		`"unterminated`,
+		`"quoted" then bare`,
+		`"`,
+	}
+	for _, content := range tests {
+		if got := unquoteTXTContent(content); got != content {
+			t.Errorf("unquoteTXTContent(%q) = %q, want the input unchanged", content, got)
+		}
 	}
 }

--- a/pkg/controller/bootstrap.go
+++ b/pkg/controller/bootstrap.go
@@ -16,7 +16,7 @@ type IngressControllerOptions struct {
 }
 
 func RegisterIngressController(logger logr.Logger, mgr manager.Manager, options IngressControllerOptions) error {
-	controller := NewIngressController(logger.WithName("ingress-controller"), mgr.GetClient(), mgr.GetEventRecorderFor("cloudflare-tunnel-ingress-controller"), options.IngressClassName, options.ControllerClassName, options.ClusterDomain, options.CFTunnelClient)
+	controller := NewIngressController(logger.WithName("ingress-controller"), mgr.GetClient(), mgr.GetEventRecorder("cloudflare-tunnel-ingress-controller"), options.IngressClassName, options.ControllerClassName, options.ClusterDomain, options.CFTunnelClient)
 	err := builder.
 		ControllerManagedBy(mgr).
 		For(&networkingv1.Ingress{}).

--- a/pkg/controller/ingress-controller.go
+++ b/pkg/controller/ingress-controller.go
@@ -12,7 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -26,14 +26,14 @@ const IngressControllerFinalizer = "strrl.dev/cloudflare-tunnel-ingress-controll
 type IngressController struct {
 	logger              logr.Logger
 	kubeClient          client.Client
-	recorder            record.EventRecorder
+	recorder            events.EventRecorder
 	ingressClassName    string
 	controllerClassName string
 	clusterDomain       string
 	tunnelClient        *cloudflarecontroller.TunnelClient
 }
 
-func NewIngressController(logger logr.Logger, kubeClient client.Client, recorder record.EventRecorder, ingressClassName string, controllerClassName string, clusterDomain string, tunnelClient *cloudflarecontroller.TunnelClient) *IngressController {
+func NewIngressController(logger logr.Logger, kubeClient client.Client, recorder events.EventRecorder, ingressClassName string, controllerClassName string, clusterDomain string, tunnelClient *cloudflarecontroller.TunnelClient) *IngressController {
 	return &IngressController{logger: logger, kubeClient: kubeClient, recorder: recorder, ingressClassName: ingressClassName, controllerClassName: controllerClassName, clusterDomain: clusterDomain, tunnelClient: tunnelClient}
 }
 
@@ -87,7 +87,7 @@ func (i *IngressController) Reconcile(ctx context.Context, request reconcile.Req
 		exposures, err := FromIngressToExposure(ctx, i.logger, i.kubeClient, i.recorder, ingress, i.clusterDomain)
 		if err != nil {
 			i.logger.Error(err, "extract exposures from ingress, skipped", "triggered-by", request.NamespacedName, "ingress", fmt.Sprintf("%s/%s", ingress.Namespace, ingress.Name))
-			i.recorder.Event(&ingress, v1.EventTypeWarning, EventReasonTransformFailed, err.Error())
+			i.recorder.Eventf(&ingress, nil, v1.EventTypeWarning, EventReasonTransformFailed, EventReasonTransformFailed, "%s", err.Error())
 		}
 		allExposures = append(allExposures, exposures...)
 	}
@@ -95,11 +95,11 @@ func (i *IngressController) Reconcile(ctx context.Context, request reconcile.Req
 
 	err = i.tunnelClient.PutExposures(ctx, allExposures)
 	if err != nil {
-		i.recorder.Event(&origin, v1.EventTypeWarning, EventReasonSyncFailed, err.Error())
+		i.recorder.Eventf(&origin, nil, v1.EventTypeWarning, EventReasonSyncFailed, EventReasonSyncFailed, "%s", err.Error())
 		return reconcile.Result{}, errors.Wrap(err, "put exposures")
 	}
 	if origin.DeletionTimestamp == nil {
-		i.recorder.Event(&origin, v1.EventTypeNormal, EventReasonSynced, "cloudflare tunnel config and DNS records are up to date")
+		i.recorder.Eventf(&origin, nil, v1.EventTypeNormal, EventReasonSynced, EventReasonSynced, "cloudflare tunnel config and DNS records are up to date")
 	}
 
 	if origin.DeletionTimestamp != nil {

--- a/pkg/controller/transform.go
+++ b/pkg/controller/transform.go
@@ -14,7 +14,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 )
 
@@ -26,12 +26,12 @@ const (
 	EventReasonSynced          = "CloudflareSynced"
 )
 
-func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient client.Client, recorder record.EventRecorder, ingress networkingv1.Ingress, clusterDomain string) ([]exposure.Exposure, error) {
+func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient client.Client, recorder events.EventRecorder, ingress networkingv1.Ingress, clusterDomain string) ([]exposure.Exposure, error) {
 	isDeleted := ingress.DeletionTimestamp != nil
 
 	if len(ingress.Spec.TLS) > 0 {
 		logger.Info("ingress has tls specified, SSL Passthrough is not supported, it will be ignored.")
-		recorder.Event(&ingress, v1.EventTypeWarning, EventReasonTLSIgnored, "ingress has tls specified, SSL Passthrough is not supported, it will be ignored")
+		recorder.Eventf(&ingress, nil, v1.EventTypeWarning, EventReasonTLSIgnored, EventReasonTLSIgnored, "ingress has tls specified, SSL Passthrough is not supported, it will be ignored")
 	}
 
 	var result []exposure.Exposure
@@ -47,7 +47,7 @@ func FromIngressToExposure(ctx context.Context, logger logr.Logger, kubeClient c
 				"ingress", fmt.Sprintf("%s/%s", ingress.GetNamespace(), ingress.GetName()),
 				"host", rule.Host,
 			)
-			recorder.Eventf(&ingress, v1.EventTypeWarning, EventReasonRuleSkipped, "rule for host %s has no http section, skipped", rule.Host)
+			recorder.Eventf(&ingress, nil, v1.EventTypeWarning, EventReasonRuleSkipped, EventReasonRuleSkipped, "rule for host %s has no http section, skipped", rule.Host)
 			continue
 		}
 

--- a/pkg/controller/transform_test.go
+++ b/pkg/controller/transform_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -157,7 +157,7 @@ func TestFromIngressToExposureNilHTTP(t *testing.T) {
 		},
 	}
 
-	recorder := record.NewFakeRecorder(8)
+	recorder := events.NewFakeRecorder(8)
 	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), nil, recorder, ingress, "cluster.local")
 	if err != nil {
 		t.Fatalf("expected a rule with nil HTTP to be skipped, got error: %v", err)
@@ -227,7 +227,7 @@ func TestFromIngressToExposureNilHTTPKeepsOtherRules(t *testing.T) {
 	}
 	kubeClient := fake.NewClientBuilder().WithObjects(&service).Build()
 
-	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), kubeClient, record.NewFakeRecorder(8), ingress, "cluster.local")
+	exposures, err := FromIngressToExposure(context.Background(), logr.Discard(), kubeClient, events.NewFakeRecorder(8), ingress, "cluster.local")
 	if err != nil {
 		t.Fatalf("expected the host-only rule to be skipped, got error: %v", err)
 	}

--- a/test/integration/controller/ingress_transform_test.go
+++ b/test/integration/controller/ingress_transform_test.go
@@ -14,7 +14,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 const IntegrationTestNamespace = "cf-tunnel-ingress-controller-test"
@@ -26,7 +26,7 @@ var pathTypeImplementationSpecific = networkingv1.PathTypeImplementationSpecific
 
 var _ = Describe("transform ingress to exposure", func() {
 	logger := stdr.NewWithOptions(log.New(os.Stderr, "", log.LstdFlags), stdr.Options{LogCaller: stdr.All})
-	recorder := record.NewFakeRecorder(100)
+	recorder := events.NewFakeRecorder(100)
 
 	It("should resolve ingress with PathType Prefix", func() {
 		// prepare


### PR DESCRIPTION
## Summary
- Replace `*` in ownership TXT names with `_wildcard` so Cloudflare no longer warns that a non-prefix star is not a wildcard. `*.example.com` becomes `_ctic_managed._wildcard.example.com`, which cannot collide with a literal `wildcard.example.com` host.
- Store ownership TXT values as RFC 1035-quoted JSON (`"{\"controller\":\"...\",\"tunnel\":\"...\"}"`).
- Existing records are rewritten automatically on the next reconcile: leftover `_ctic_managed.*.<domain>` names are replaced, and unquoted JSON is quoted in place. The CNAME is unchanged. No manual DNS edits are required.